### PR TITLE
Custom BM Meteors

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -118,6 +118,9 @@ public class AlchemicalWizardry
     public static int ironBlockMeteorRadius;
     public static String[] netherStarMeteorArray;
     public static int netherStarMeteorRadius;
+    //add new meteor
+    public static String[] netherWartMeteorArray;
+    public static int netherWartMeteorRadius;
 
     public static String[] allowedCrushedOresArray;
 
@@ -893,6 +896,8 @@ public class AlchemicalWizardry
         MeteorRegistry.registerMeteorParadigm(stoneStack, stoneMeteorArray, stoneMeteorRadius);
         MeteorRegistry.registerMeteorParadigm(ironBlockStack, ironBlockMeteorArray, ironBlockMeteorRadius);
         MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_star), netherStarMeteorArray, netherStarMeteorRadius);
+        //add new meteor
+        MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_wart), netherWartMeteorArray, netherWartMeteorRadius);
 
         ItemStack stickStack = new ItemStack(Items.stick, 1, craftingConstant);
 

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -119,8 +119,8 @@ public class AlchemicalWizardry
     public static String[] netherStarMeteorArray;
     public static int netherStarMeteorRadius;
     //add new meteor
-    public static String[] netherWartMeteorArray;
-    public static int netherWartMeteorRadius;
+    public static String[] BPMeteorArray;
+    public static int BPMeteorRadius;
 
     public static String[] allowedCrushedOresArray;
 
@@ -897,7 +897,7 @@ public class AlchemicalWizardry
         MeteorRegistry.registerMeteorParadigm(ironBlockStack, ironBlockMeteorArray, ironBlockMeteorRadius);
         MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_star), netherStarMeteorArray, netherStarMeteorRadius);
         //add new meteor
-        MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_wart), netherWartMeteorArray, netherWartMeteorRadius);
+        MeteorRegistry.registerMeteorParadigm(new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 388), BPMeteorArray, BPMeteorRadius);
 
         ItemStack stickStack = new ItemStack(Items.stick, 1, craftingConstant);
 

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -77,6 +77,7 @@ import cpw.mods.fml.common.event.*;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.util.GT_ModHandler;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -897,8 +898,19 @@ public class AlchemicalWizardry
         MeteorRegistry.registerMeteorParadigm(ironBlockStack, ironBlockMeteorArray, ironBlockMeteorRadius);
         MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_star), netherStarMeteorArray, netherStarMeteorRadius);
         //add new meteor
-        MeteorRegistry.registerMeteorParadigm(new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 388), BPMeteorArray, BPMeteorRadius);
-
+        //MeteorRegistry.registerMeteorParadigm(new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 388), BPMeteorArray, BPMeteorRadius);
+        //ItemStack diamondStack = new ItemStack(Items.diamond, 1, craftingConstant);
+        //ItemStack itemGoggles = ItemApi.getItem("itemGoggles", 0);
+        //Item itemThaumChest = GameRegistry.findItem("Thaumcraft", "ItemChestplateThaumium");
+        //ItemStack BPBlock = ItemApi.getItem("tile.BlackPlutonium", 0);
+        //ItemStack BPBlock = GameRegistry.findItem("dreamcraft", "tile.BlackPlutonium");
+        //ItemStack BPBlock = new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 0);
+        //ItemStack BPBlock = GameRegistry.findItemStack("dreamcraft", "tile.BlackPlutonium", 1); 	This
+        //MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);			and this work
+        ItemStack BPBlock = GT_ModHandler.getModItem("gregtech", "gt.blockores", 1, 6); //lithium ore
+        MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);
+        
+        //6
         ItemStack stickStack = new ItemStack(Items.stick, 1, craftingConstant);
 
         //Register spell component recipes

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -111,18 +111,23 @@ public class AlchemicalWizardry
 	public static boolean parseTextFiles = false;
 
     public static boolean doMeteorsDestroyBlocks = true;
-    public static String[] diamondMeteorArray;
-    public static int diamondMeteorRadius;
-    public static String[] stoneMeteorArray;
-    public static int stoneMeteorRadius;
-    public static String[] ironBlockMeteorArray;
-    public static int ironBlockMeteorRadius;
-    public static String[] netherStarMeteorArray;
-    public static int netherStarMeteorRadius;
+    public static String[] Meteor00Array;
+    public static int Meteor00Radius;
+    public static int Meteor00Cost;
+    public static String[] Meteor01Array;
+    public static int Meteor01Radius;
+    public static int Meteor01Cost;
+    public static String[] Meteor02Array;
+    public static int Meteor02Radius;
+    public static int Meteor02Cost;
+    public static String[] Meteor03Array;
+    public static int Meteor03Radius;
+    public static int Meteor03Cost;
     //add new meteor
-    public static String[] BPMeteorArray;
-    public static int BPMeteorRadius;
-
+    public static String[] Meteor04Array;
+    public static int Meteor04Radius;
+    public static int Meteor04Cost;
+    
     public static String[] allowedCrushedOresArray;
 
     public static Potion customPotionDrowning;
@@ -893,24 +898,17 @@ public class AlchemicalWizardry
 
         //Ore Dictionary Registration
         OreDictionary.registerOre("oreCoal", Blocks.coal_ore);
-        MeteorRegistry.registerMeteorParadigm(diamondStack, diamondMeteorArray, diamondMeteorRadius);
-        MeteorRegistry.registerMeteorParadigm(stoneStack, stoneMeteorArray, stoneMeteorRadius);
-        MeteorRegistry.registerMeteorParadigm(ironBlockStack, ironBlockMeteorArray, ironBlockMeteorRadius);
-        MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_star), netherStarMeteorArray, netherStarMeteorRadius);
+        MeteorRegistry.registerMeteorParadigm(diamondStack, Meteor00Array, Meteor00Radius);
+        MeteorRegistry.registerMeteorParadigm(stoneStack, Meteor01Array, Meteor01Radius);
+        MeteorRegistry.registerMeteorParadigm(ironBlockStack, Meteor02Array, Meteor02Radius);
+        MeteorRegistry.registerMeteorParadigm(new ItemStack(Items.nether_star), Meteor03Array, Meteor03Radius);
         //add new meteor
-        //MeteorRegistry.registerMeteorParadigm(new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 388), BPMeteorArray, BPMeteorRadius);
-        //ItemStack diamondStack = new ItemStack(Items.diamond, 1, craftingConstant);
-        //ItemStack itemGoggles = ItemApi.getItem("itemGoggles", 0);
-        //Item itemThaumChest = GameRegistry.findItem("Thaumcraft", "ItemChestplateThaumium");
-        //ItemStack BPBlock = ItemApi.getItem("tile.BlackPlutonium", 0);
-        //ItemStack BPBlock = GameRegistry.findItem("dreamcraft", "tile.BlackPlutonium");
-        //ItemStack BPBlock = new ItemStack(dreamcraft.tile.BlackPlutonium, 1, 0);
-        //ItemStack BPBlock = GameRegistry.findItemStack("dreamcraft", "tile.BlackPlutonium", 1); 	This
-        //MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);			and this work
-        ItemStack BPBlock = GT_ModHandler.getModItem("gregtech", "gt.blockores", 1, 6); //lithium ore
-        MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);
+        //ItemStack BPBlock = GameRegistry.findItemStack("dreamcraft", "tile.BlackPlutonium", 1); 	//Use Black Plutonium block as catalyst to summon
+        //MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);			//continued
         
-        //6
+        ItemStack BPBlock = GT_ModHandler.getModItem("gregtech", "gt.blockores", 1, 6); 			//Use Lithium Ore as catalyst to summon
+        MeteorRegistry.registerMeteorParadigm(BPBlock, Meteor04Array, Meteor04Radius);				//catalysts are paradigms in this version of BM     
+        
         ItemStack stickStack = new ItemStack(Items.stick, 1, craftingConstant);
 
         //Register spell component recipes

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -29,6 +29,7 @@ import WayofTime.alchemicalWizardry.api.sacrifice.PlayerSacrificeHandler;
 import WayofTime.alchemicalWizardry.api.soulNetwork.ComplexNetworkHandler;
 import WayofTime.alchemicalWizardry.api.spell.*;
 import WayofTime.alchemicalWizardry.api.summoningRegistry.SummoningRegistry;
+import WayofTime.alchemicalWizardry.api.util.BMModHandler;
 import WayofTime.alchemicalWizardry.common.*;
 import WayofTime.alchemicalWizardry.common.achievements.ModAchievements;
 import WayofTime.alchemicalWizardry.common.alchemy.CombinedPotionRegistry;
@@ -77,7 +78,7 @@ import cpw.mods.fml.common.event.*;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
-import gregtech.api.util.GT_ModHandler;
+//import gregtech.api.util.GT_ModHandler;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -906,7 +907,7 @@ public class AlchemicalWizardry
         //ItemStack BPBlock = GameRegistry.findItemStack("dreamcraft", "tile.BlackPlutonium", 1); 	//Use Black Plutonium block as catalyst to summon
         //MeteorRegistry.registerMeteorParadigm(BPBlock, BPMeteorArray, BPMeteorRadius);			//continued
         
-        ItemStack BPBlock = GT_ModHandler.getModItem("gregtech", "gt.blockores", 1, 6); 			//Use Lithium Ore as catalyst to summon
+        ItemStack BPBlock = BMModHandler.getModItem("gregtech", "gt.blockores", 1, 6); 			//Use Lithium Ore as catalyst to summon
         MeteorRegistry.registerMeteorParadigm(BPBlock, Meteor04Array, Meteor04Radius);				//catalysts are paradigms in this version of BM     
         
         ItemStack stickStack = new ItemStack(Items.stick, 1, craftingConstant);

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -102,18 +102,23 @@ public class BloodMagicConfiguration
 		AlchemicalWizardry.customPotionAmphibianID = config.get("Potion ID", "Amphibian", 116).getInt();
 
 		MeteorParadigm.maxChance = config.get("meteor", "maxChance", 1000).getInt();
-		AlchemicalWizardry.doMeteorsDestroyBlocks = config.get("meteor", "doMeteorsDestroyBlocks", true).getBoolean(true);
-		AlchemicalWizardry.diamondMeteorArray = config.get("meteor", "diamondMeteor", new String[]{"oreDiamond", "100", "oreEmerald", "75", "oreCinnabar", "200", "oreAmber", "200"}).getStringList();
-		AlchemicalWizardry.diamondMeteorRadius = config.get("meteor", "diamondMeteorRadius", 5).getInt();
-		AlchemicalWizardry.stoneMeteorArray = config.get("meteor", "stoneBlockMeteor", new String[]{"oreCoal", "150", "oreApatite", "50", "oreIron", "50"}).getStringList();
-		AlchemicalWizardry.stoneMeteorRadius = config.get("meteor", "stoneMeteorRadius", 16).getInt();
-		AlchemicalWizardry.ironBlockMeteorArray = config.get("meteor", "ironBlockMeteor", new String[]{"oreIron", "400", "oreGold", "30", "oreCopper", "200", "oreTin", "140", "oreSilver", "70", "oreLead", "80", "oreLapis", "60", "oreRedstone", "100"}).getStringList();
-		AlchemicalWizardry.ironBlockMeteorRadius = config.get("meteor", "ironBlockMeteorRadius", 7).getInt();
-		AlchemicalWizardry.netherStarMeteorArray = config.get("meteor", "netherStarMeteor", new String[]{"oreDiamond", "150", "oreEmerald", "100", "oreQuartz", "250", "oreSunstone", "5", "oreMoonstone", "50", "oreIridium", "5", "oreCertusQuartz", "150"}).getStringList();
-		AlchemicalWizardry.netherStarMeteorRadius = config.get("meteor", "netherStarMeteorRadius", 3).getInt();
+		AlchemicalWizardry.doMeteorsDestroyBlocks = config.get("meteor", "doMeteorsDestroyBlocks", false).getBoolean(true);
+		AlchemicalWizardry.Meteor00Array = config.get("meteor", "Meteor00", new String[]{"oreDiamond", "1000"}).getStringList();
+		AlchemicalWizardry.Meteor00Radius = config.get("meteor", "Meteor00Radius", 5).getInt();
+		AlchemicalWizardry.Meteor00Cost = config.get("meteor", "Meteor00Cost", 5000).getInt();
+		AlchemicalWizardry.Meteor01Array = config.get("meteor", "Meteor01", new String[]{"oreCoal", "1000"}).getStringList();
+		AlchemicalWizardry.Meteor01Radius = config.get("meteor", "Meteor01Radius", 5).getInt();
+		AlchemicalWizardry.Meteor01Cost = config.get("meteor", "Meteor01Cost", 10000).getInt();
+		AlchemicalWizardry.Meteor02Array = config.get("meteor", "Meteor02", new String[]{"oreIron", "1000"}).getStringList();
+		AlchemicalWizardry.Meteor02Radius = config.get("meteor", "Meteor02Radius", 5).getInt();
+		AlchemicalWizardry.Meteor02Cost = config.get("meteor", "Meteor02Cost", 30000).getInt();
+		AlchemicalWizardry.Meteor03Array = config.get("meteor", "Meteor03", new String[]{"oreEmerald", "1000"}).getStringList();
+		AlchemicalWizardry.Meteor03Radius = config.get("meteor", "Meteor03Radius", 5).getInt();
+		AlchemicalWizardry.Meteor03Cost = config.get("meteor", "Meteor03Cost", 50000).getInt();
 		//add new meteor
-		AlchemicalWizardry.BPMeteorArray = config.get("meteor", "BPMeteor", new String[]{"oreBlackPlutonium", "1000"}).getStringList();
-		AlchemicalWizardry.BPMeteorRadius = config.get("meteor", "BPMeteorRadius", 3).getInt();
+		AlchemicalWizardry.Meteor04Array = config.get("meteor", "Meteor04", new String[]{"oreLithium", "1000"}).getStringList();
+		AlchemicalWizardry.Meteor04Radius = config.get("meteor", "Meteor04Radius", 5).getInt();
+		AlchemicalWizardry.Meteor04Cost = config.get("meteor", "Meteor04Cost", 70000).getInt();
 
 		AlchemicalWizardry.allowedCrushedOresArray = config.get("oreCrushing", "allowedOres", new String[]{"iron", "gold", "copper", "tin", "lead", "silver", "osmium"}).getStringList();
 

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -112,8 +112,8 @@ public class BloodMagicConfiguration
 		AlchemicalWizardry.netherStarMeteorArray = config.get("meteor", "netherStarMeteor", new String[]{"oreDiamond", "150", "oreEmerald", "100", "oreQuartz", "250", "oreSunstone", "5", "oreMoonstone", "50", "oreIridium", "5", "oreCertusQuartz", "150"}).getStringList();
 		AlchemicalWizardry.netherStarMeteorRadius = config.get("meteor", "netherStarMeteorRadius", 3).getInt();
 		//add new meteor
-		AlchemicalWizardry.netherWartMeteorArray = config.get("meteor", "netherWartMeteor", new String[]{"oreDiamond", "1000"}).getStringList();
-		AlchemicalWizardry.netherWartMeteorRadius = config.get("meteor", "netherWartMeteorRadius", 5).getInt();
+		AlchemicalWizardry.BPMeteorArray = config.get("meteor", "BPMeteor", new String[]{"oreBlackPlutonium", "1000"}).getStringList();
+		AlchemicalWizardry.BPMeteorRadius = config.get("meteor", "BPMeteorRadius", 3).getInt();
 
 		AlchemicalWizardry.allowedCrushedOresArray = config.get("oreCrushing", "allowedOres", new String[]{"iron", "gold", "copper", "tin", "lead", "silver", "osmium"}).getStringList();
 

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -111,6 +111,9 @@ public class BloodMagicConfiguration
 		AlchemicalWizardry.ironBlockMeteorRadius = config.get("meteor", "ironBlockMeteorRadius", 7).getInt();
 		AlchemicalWizardry.netherStarMeteorArray = config.get("meteor", "netherStarMeteor", new String[]{"oreDiamond", "150", "oreEmerald", "100", "oreQuartz", "250", "oreSunstone", "5", "oreMoonstone", "50", "oreIridium", "5", "oreCertusQuartz", "150"}).getStringList();
 		AlchemicalWizardry.netherStarMeteorRadius = config.get("meteor", "netherStarMeteorRadius", 3).getInt();
+		//add new meteor
+		AlchemicalWizardry.netherWartMeteorArray = config.get("meteor", "netherWartMeteor", new String[]{"oreDiamond", "1000"}).getStringList();
+		AlchemicalWizardry.netherWartMeteorRadius = config.get("meteor", "netherWartMeteorRadius", 5).getInt();
 
 		AlchemicalWizardry.allowedCrushedOresArray = config.get("oreCrushing", "allowedOres", new String[]{"iron", "gold", "copper", "tin", "lead", "silver", "osmium"}).getStringList();
 

--- a/src/main/java/WayofTime/alchemicalWizardry/api/util/BMModHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/util/BMModHandler.java
@@ -1,0 +1,75 @@
+package WayofTime.alchemicalWizardry.api.util;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+//import gregtech.api.GregTech_API;
+//import gregtech.api.util.GT_Utility;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+//contains code borrowed from GT
+//BTW did I need all of these? What's the replacement thing for?
+
+public class BMModHandler {
+
+    /**
+     * Gets an Item from RailCraft
+     */
+    public static ItemStack getModItem(String aModID, String aItem, long aAmount) {
+        return getModItem(aModID, aItem, aAmount, null);
+    }
+
+    /**
+     * Gets an Item from RailCraft, and returns a Replacement Item if not possible
+     */
+    public static ItemStack getModItem(String aModID, String aItem, long aAmount, ItemStack aReplacement) {
+        if (isStringInvalid(aItem) /*|| !GregTech_API.sPreloadStarted*/) return null; //what did this do? Is it important?
+        return copyAmount(aAmount, GameRegistry.findItemStack(aModID, aItem, (int) aAmount), aReplacement);
+    }
+
+    /**
+     * Gets an Item from RailCraft, but the Damage Value can be specified
+     */
+    public static ItemStack getModItem(String aModID, String aItem, long aAmount, int aMeta) {
+        ItemStack rStack = getModItem(aModID, aItem, aAmount);
+        if (rStack == null) return null;
+        Items.feather.setDamage(rStack, aMeta);
+        return rStack;
+    }
+
+    /**
+     * Gets an Item from RailCraft, but the Damage Value can be specified, and returns a Replacement Item with the same Damage if not possible
+     */
+    public static ItemStack getModItem(String aModID, String aItem, long aAmount, int aMeta, ItemStack aReplacement) {
+        ItemStack rStack = getModItem(aModID, aItem, aAmount, aReplacement);
+        if (rStack == null) return null;
+        Items.feather.setDamage(rStack, aMeta);
+        return rStack;
+    }
+    
+    public static boolean isStringInvalid(Object aString) {
+        return aString == null || aString.toString().isEmpty();
+    }
+        
+    public static boolean isStackValid(Object aStack) {
+        return (aStack instanceof ItemStack) && ((ItemStack) aStack).getItem() != null && ((ItemStack) aStack).stackSize >= 0;
+    }
+    
+    public static boolean isStackInvalid(Object aStack) {
+        return aStack == null || !(aStack instanceof ItemStack) || ((ItemStack) aStack).getItem() == null || ((ItemStack) aStack).stackSize < 0;
+    }
+    
+    public static ItemStack copy(Object... aStacks) {
+        for (Object tStack : aStacks) if (isStackValid(tStack)) return ((ItemStack) tStack).copy();
+        return null;
+    }
+    
+    public static ItemStack copyAmount(long aAmount, Object... aStacks) {
+        ItemStack rStack = copy(aStacks);
+        if (isStackInvalid(rStack)) return null;
+        if (aAmount > 64) aAmount = 64;
+        else if (aAmount == -1) aAmount = 111;
+        else if (aAmount < 0) aAmount = 0;
+        rStack.stackSize = (byte) aAmount;
+        return rStack;
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectSummonMeteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectSummonMeteor.java
@@ -21,7 +21,9 @@ import java.util.List;
 
 public class RitualEffectSummonMeteor extends RitualEffect
 {
-    @Override
+	private static int meteorID;
+
+	@Override
     public void performEffect(IMasterRitualStone ritualStone)
     {
         String owner = ritualStone.getOwner();
@@ -36,32 +38,33 @@ public class RitualEffectSummonMeteor extends RitualEffect
         {
             ritualStone.setCooldown(0);
         }
+  
+        List<EntityItem> entities = world.getEntitiesWithinAABB(EntityItem.class, AxisAlignedBB.getBoundingBox(x, y + 1, z, x + 1, y + 2, z + 1));
 
-        if (currentEssence < this.getCostPerRefresh())
+        if (entities == null)
         {
-            EntityPlayer entityOwner = SpellHelper.getPlayerForUsername(owner);
+            return;
+        }
 
-            if (entityOwner == null)
-            {
-                return;
-            }
-
-            entityOwner.addPotionEffect(new PotionEffect(Potion.confusion.id, 80));
-        } else
+        for (EntityItem entityItem : entities)
         {
-            List<EntityItem> entities = world.getEntitiesWithinAABB(EntityItem.class, AxisAlignedBB.getBoundingBox(x, y + 1, z, x + 1, y + 2, z + 1));
-
-            if (entities == null)
+            if (entityItem != null && MeteorRegistry.isValidParadigmItem(entityItem.getEntityItem()))
             {
-                return;
-            }
-
-            for (EntityItem entityItem : entities)
-            {
-                if (entityItem != null && MeteorRegistry.isValidParadigmItem(entityItem.getEntityItem()))
+                meteorID = MeteorRegistry.getParadigmIDForItem(entityItem.getEntityItem());
+                if (currentEssence < this.getCostPerRefresh())
                 {
-                    int meteorID = MeteorRegistry.getParadigmIDForItem(entityItem.getEntityItem());
-                    EntityMeteor meteor = new EntityMeteor(world, x + 0.5f, 257, z + 0.5f, meteorID);
+                    EntityPlayer entityOwner = SpellHelper.getPlayerForUsername(owner);
+
+                    if (entityOwner == null)
+                    {
+                        return;
+                    }
+
+                    entityOwner.addPotionEffect(new PotionEffect(Potion.confusion.id, 80));
+                }
+                else
+                {
+                	EntityMeteor meteor = new EntityMeteor(world, x + 0.5f, 257, z + 0.5f, meteorID);
                     meteor.motionY = -1.0f;
 
                     if (this.canDrainReagent(ritualStone, ReagentRegistry.terraeReagent, 1000, true))
@@ -88,20 +91,42 @@ public class RitualEffectSummonMeteor extends RitualEffect
                     entityItem.setDead();
                     world.spawnEntityInWorld(meteor);
                     ritualStone.setActive(false);
+                    SoulNetworkHandler.syphonFromNetwork(owner, this.getCostPerRefresh());
                     break;
                 }
             }
-
-            SoulNetworkHandler.syphonFromNetwork(owner, this.getCostPerRefresh());
         }
-    }
-
-    @Override
+	}
+   
+	@Override
     public int getCostPerRefresh()
-    {
-        return AlchemicalWizardry.ritualCostFallingTower[1];
+    {	
+		if (meteorID == 0 )//Meteor00
+    	{
+    		return AlchemicalWizardry.Meteor00Cost;
+       	}
+    	else if (meteorID == 1 )//Meteor01
+    	{
+    		return AlchemicalWizardry.Meteor01Cost;
+    	}
+    	else if (meteorID == 2 )//Meteor02
+    	{
+    		return AlchemicalWizardry.Meteor02Cost;
+    	}
+    	else if (meteorID == 3 )//Meteor03
+    	{
+    		return AlchemicalWizardry.Meteor03Cost;
+    	}
+    	else if (meteorID == 4 )//Meteor04
+    	{
+    		return AlchemicalWizardry.Meteor04Cost;
+    	}
+    	else //fail, or initial right click. Can't fix :( But default can be set to 0
+    	{	//otherwise you pay 1M(or what's in the config) LP for activating MRS, then again for the specific meteor
+    		return AlchemicalWizardry.ritualCostFallingTower[1];
+    	}
     }
-
+    
     @Override
     public List<RitualComponent> getRitualComponentList()
     {


### PR DESCRIPTION
I finally managed to make the LP costs of BM meteors configurable per meteor type as well as use catalysts/paradigms from other mods+metadata, so we can have all kinds of crazy meteors now. But I'd like it if someone did a code review first, since I'm not a professional coder and I'm sure I did it all wrong or something. Or rather, even I think it's bad. It does work though. If you want to test it, you need to regen the config file first, or do so and copy the changes over. Also note that this resets the altar materials to stone bricks.

There's also the 1.12 version of the original repo one that I couldn't copy because it's too different if that helps out: https://github.com/WayofTime/BloodMagic/commit/d1455920ec7f8bff1818c7c9067013123231f0c5 , and https://github.com/WayofTime/BloodMagic/commit/31c606495c276ea66cefd8a347b2e6a63c09a2d5

Definitely should not be merged at this point, as it's not balanced and removes the previously customized meteors' contents. Also more meteors need to be added and LP amounts decided, etc. That belongs in an actual ticket once the code part is done though.