### PR TITLE
Fix teleposer costing no LP with interdim travel

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
@@ -2,7 +2,6 @@ package WayofTime.alchemicalWizardry.common.tileEntity;
 
 import java.util.Iterator;
 import java.util.List;
-import 
 
 import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
 import net.minecraft.entity.EntityLivingBase;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
@@ -146,10 +146,14 @@ public class TETeleposer extends TEInventory
                         {
                             entityCount = 0;
                         }
-
-                        SoulNetworkHandler.syphonFromNetwork(focus, damage * transportCount + damage * entityCount);
-                        //Teleport
-
+			
+                        //Teleport			
+			if (damage * transportCount + damage * entityCount < 2000) {
+				SoulNetworkHandler.syphonFromNetwork(focus, 2000);
+			} else {
+				SoulNetworkHandler.syphonFromNetwork(focus, damage * transportCount + damage * entityCount);
+			}
+			
                         if (worldF.equals(worldObj))
                         {
                             iterator1 = list1.iterator();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TETeleposer.java
@@ -2,6 +2,7 @@ package WayofTime.alchemicalWizardry.common.tileEntity;
 
 import java.util.Iterator;
 import java.util.List;
+import 
 
 import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
 import net.minecraft.entity.EntityLivingBase;
@@ -147,12 +148,9 @@ public class TETeleposer extends TEInventory
                             entityCount = 0;
                         }
 			
-                        //Teleport			
-			if (damage * transportCount + damage * entityCount < 2000) {
-				SoulNetworkHandler.syphonFromNetwork(focus, 2000);
-			} else {
-				SoulNetworkHandler.syphonFromNetwork(focus, damage * transportCount + damage * entityCount);
-			}
+                        //Teleport with minimum cost of 2000 LP.
+			int cost = Math.max(damage * transportCount + damage * entityCount, 2000);
+			SoulNetworkHandler.syphonFromNetwork(focus, cost);
 			
                         if (worldF.equals(worldObj))
                         {


### PR DESCRIPTION
The teleposer currently costs no LP if the x, y and z coordinates of your teleposers are the same between the dimensions you're teleporting between. This adds a base cost of 2000 making sure it will always drain some LP. This is a very simple PR but I don't program in java usually so appreciate scrutiny :p