### PR TITLE
Allow meteor config file to specify blocks by ID and metadata.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,19 +23,19 @@
  */
 
 dependencies {
-    api("com.github.GTNewHorizons:waila:1.7.0:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev")
+    api("com.github.GTNewHorizons:waila:1.7.1:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.25-GTNH:dev")
     
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.41:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.126:dev") {transitive = false }
     
-    compileOnly("com.github.GTNewHorizons:Botania:1.10.5-GTNH:api") {transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.2:api") {transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.4.7:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.10.12-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.7:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.4.8:dev") {transitive = false }
     
-    compileOnly("com.github.GTNewHorizons:Chisel:2.13.4-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Chisel:2.14.1-GTNH:api") {transitive = false }
     
     compileOnly("com.github.GTNewHorizons:ZenScript:1.0.0-GTNH") {transitive = false }
-    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.3.0:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.3.1:dev") {transitive = false }
 
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false }
     compileOnly("curse.maven:guide-api-228832:2287185") {transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 gtnh.settings.blowdryerTag = 0.2.0
 
 # Human-readable mod name, available for mcmod.info population.
-modName = Blood Magic: Alchemical Wizardry
+modName = Blood Magic\: Alchemical Wizardry
 
 # Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
 # Conventionally lowercase.
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ disableCheckstyle = true
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -43,7 +42,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
 
             float totalMeteorWeight = meteor.getTotalMeteorWeight();
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
-            sortedComponents.sort(Comparator.comparingInt(c -> -c.chance));
+            sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
             for (MeteorParadigmComponent component : sortedComponents) {
                 ItemStack stack = component.getValidBlockParadigm();
@@ -51,10 +50,6 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                if (stack == null) {
-                    stack = new ItemStack(Blocks.fire);
-                    tooltips.add(String.format("no entries found for oredict \"%s\"", component.getOreDictName()));
-                }
                 float chance = component.getChance() / totalMeteorWeight;
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigmComponent.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigmComponent.java
@@ -1,31 +1,15 @@
 package WayofTime.alchemicalWizardry.common.summoning.meteor;
 
-import java.util.List;
-
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.oredict.OreDictionary;
 
 public class MeteorParadigmComponent {
 
-    public String oreDictName;
-    public int chance;
+    protected int chance;
+    protected ItemStack itemStack;
 
-    public MeteorParadigmComponent(String dictName, int chance) {
-        this.oreDictName = dictName;
+    public MeteorParadigmComponent(ItemStack stack, int chance) {
+        this.itemStack = stack;
         this.chance = chance;
-    }
-
-    public boolean isValidBlockParadigm() {
-        if (this.getValidBlockParadigm() != null) {
-            return true;
-        }
-
-        return false;
-    }
-
-    public String getOreDictName() {
-        return this.oreDictName;
     }
 
     public int getChance() {
@@ -33,14 +17,6 @@ public class MeteorParadigmComponent {
     }
 
     public ItemStack getValidBlockParadigm() {
-        List<ItemStack> list = OreDictionary.getOres(getOreDictName());
-
-        for (ItemStack stack : list) {
-            if (stack != null && stack.getItem() instanceof ItemBlock) {
-                return stack;
-            }
-        }
-
-        return null;
+        return itemStack;
     }
 }


### PR DESCRIPTION
This PR does two related things:

---

(Part 1) Adds new options for specifying paradigms (= blocks spawned) for meteors in the config file. The two new formats are:

`<modID>:<itemName>:<meta>:<weight>`

For example, `"GalacticraftCore:tile.moonBlock:3:20"`.

`OREDICT:<oredictTag>:<weight>`

For example, `"OREDICT:oreNetherrackRedstone:100"`.

The old format, which has one entry for the oredict tag, followed by a second entry for the weight, is still supported; and all three formats can be used interchangeably in the same definition.

<details><summary>Example config file</summary>

```json
{
  "ores": [
    "minecraft:planks:0:100",
    "minecraft:planks:1:100",
    "minecraft:planks:2:100",
    "minecraft:planks:3:100",
    "OREDICT:oreIron:100",
    "OREDICT:oreGold:100",
    "blockGold",
    "100",
    "blockIron",
    "100"
  ],
  "radius": 8,
  "cost": 200,
  "focusModId": "minecraft",
  "focusName": "dirt",
  "focusMeta": 0
}
```
</details>

This allows specifying spawned blocks precisely, without having to rely solely on oredict tags. In particular, this allows for meteors that spawn different variants of planet blocks (e.g., moon rock, turf, dirt), as those are not distinguished by oredict. This would address https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15711, as well as make meteors more future-proof for adding new blocks.

---

(Part 2) The `ItemStack` specifying the blocks to be spawned is now precalculated once, at load time. Previously, the ritual would do an oredict lookup for *every block spawned by the meteor separately.* Yes, if a meteor has tens of thousands of blocks, it would attempt that many oredict lookups every time a meteor is spawned.

The difference in performance is clearly visible, even the largest possible meteor spawns nearly instantaneously. The delay is unnoticeable for smaller meteors.

https://github.com/GTNewHorizons/BloodMagic/assets/19243993/cc47b735-cf0f-4a2e-9936-9235a409ac45

---

I am respectful of the feature freeze, and I don't mind delaying this until after the release. However, merging this now would make resolving https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15711 a simple matter of editing the relevant meteor config files. I made sure that the old format files are read without any issue (tested in full pack), and the parser right now does not even attempt to convert the old format to the new one (although this is easily doable).