### PR TITLE
Fix client-side crash on servers

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,16 +24,16 @@
 
 dependencies {
     api("com.github.GTNewHorizons:waila:1.7.3:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.27-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.6.0-GTNH:dev")
     
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.02:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.05:dev") {transitive = false }
     
-    compileOnly("com.github.GTNewHorizons:Botania:1.10.12-GTNH:api") {transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.9:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.11.0-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.0:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.4.8:dev") {transitive = false }
     
     compileOnly("com.github.GTNewHorizons:Chisel:2.14.1-GTNH:api") {transitive = false }
-    
+
     compileOnly("com.github.GTNewHorizons:ZenScript:1.0.0-GTNH") {transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.3.1:dev") {transitive = false }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -1,6 +1,5 @@
 package WayofTime.alchemicalWizardry.api.soulNetwork;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,6 +14,7 @@ import WayofTime.alchemicalWizardry.api.event.AddToNetworkEvent;
 import WayofTime.alchemicalWizardry.api.event.ItemBindEvent;
 import WayofTime.alchemicalWizardry.api.event.ItemDrainInContainerEvent;
 import WayofTime.alchemicalWizardry.api.event.ItemDrainNetworkEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.Event.Result;
 

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -1,5 +1,6 @@
 package WayofTime.alchemicalWizardry.api.soulNetwork;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -35,11 +36,12 @@ public class SoulNetworkHandler {
     }
 
     public static int getCurrentMaxOrb(String ownerName) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return 0;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
 
         if (data == null) {
@@ -51,11 +53,12 @@ public class SoulNetworkHandler {
     }
 
     public static void setMaxOrbToMax(String ownerName, int maxOrb) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
 
         if (data == null) {
@@ -96,7 +99,7 @@ public class SoulNetworkHandler {
     }
 
     public static int syphonFromNetwork(String ownerName, int damageToBeDone) {
-        MinecraftServer mcServer = MinecraftServer.getServer();
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
         if (mcServer == null || mcServer.worldServers.length == 0) {
             return 0;
         }
@@ -192,11 +195,12 @@ public class SoulNetworkHandler {
     }
 
     public static boolean canSyphonFromOnlyNetwork(String ownerName, int damageToBeDone) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return false;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
 
         if (data == null) {
@@ -208,11 +212,12 @@ public class SoulNetworkHandler {
     }
 
     public static int getCurrentEssence(String ownerName) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return 0;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
 
         if (data == null) {
@@ -224,11 +229,12 @@ public class SoulNetworkHandler {
     }
 
     public static void setCurrentEssence(String ownerName, int essence) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
 
         if (data == null) {
@@ -255,11 +261,12 @@ public class SoulNetworkHandler {
             return 0;
         }
 
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return 0;
         }
 
-        World world = MinecraftServer.getServer().worldServers[0];
+        World world = mcServer.worldServers[0];
         LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, event.ownerNetwork);
 
         if (data == null) {
@@ -348,10 +355,11 @@ public class SoulNetworkHandler {
     }
 
     public static EntityPlayer getPlayerForUsername(String str) {
-        if (MinecraftServer.getServer() == null) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
             return null;
         }
-        return MinecraftServer.getServer().getConfigurationManager().func_152612_a(str);
+        return mcServer.getConfigurationManager().func_152612_a(str);
     }
 
     public static void causeNauseaToPlayer(ItemStack stack) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryFuelHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryFuelHandler.java
@@ -1,5 +1,6 @@
 package WayofTime.alchemicalWizardry.common;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -35,11 +36,12 @@ public class AlchemicalWizardryFuelHandler implements IFuelHandler {
                     return 0;
                 }
 
-                if (MinecraftServer.getServer() == null) {
+                MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+                if (mcServer == null) {
                     return 0;
                 }
 
-                if (MinecraftServer.getServer().getConfigurationManager() == null) {
+                if (mcServer.getConfigurationManager() == null) {
                     return 0;
                 }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryFuelHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryFuelHandler.java
@@ -1,6 +1,5 @@
 package WayofTime.alchemicalWizardry.common;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -12,6 +11,7 @@ import net.minecraft.server.MinecraftServer;
 import WayofTime.alchemicalWizardry.ModItems;
 import WayofTime.alchemicalWizardry.common.items.LavaCrystal;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.IFuelHandler;
 
 public class AlchemicalWizardryFuelHandler implements IFuelHandler {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/LavaCrystal.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/LavaCrystal.java
@@ -2,6 +2,7 @@ package WayofTime.alchemicalWizardry.common.items;
 
 import java.util.List;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -72,7 +73,7 @@ public class LavaCrystal extends EnergyItems {
         if (itemStack.getTagCompound() != null && !(itemStack.getTagCompound().getString("ownerName").equals(""))) {
             String ownerName = itemStack.getTagCompound().getString("ownerName");
 
-            if (MinecraftServer.getServer() == null) {
+            if (FMLCommonHandler.instance().getMinecraftServerInstance() == null) {
                 return false;
             }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/LavaCrystal.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/LavaCrystal.java
@@ -2,11 +2,9 @@ package WayofTime.alchemicalWizardry.common.items;
 
 import java.util.List;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
@@ -14,6 +12,7 @@ import net.minecraftforge.common.DimensionManager;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import WayofTime.alchemicalWizardry.api.soulNetwork.LifeEssenceNetwork;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 


### PR DESCRIPTION
`MinecraftServer.getServer()` will return the integrated server instance if the player has opened a singleplayer world in the same session while  `FMLCommonHandler.instance().getMinecraftServerInstance()` correctly returns null.

This problem has also been addressed earlier here https://github.com/GTNewHorizons/BloodMagic/pull/37 but that only covered one method.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16189