### PR TITLE
Fix teleposer unable to teleport to the end

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,13 +26,13 @@ dependencies {
     api("com.github.GTNewHorizons:waila:1.7.3:dev")
     api("com.github.GTNewHorizons:NotEnoughItems:2.6.0-GTNH:dev")
     
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.05:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.18:dev") {transitive = false }
     
-    compileOnly("com.github.GTNewHorizons:Botania:1.11.0-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.11.1-GTNH:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.0:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.4.8:dev") {transitive = false }
     
-    compileOnly("com.github.GTNewHorizons:Chisel:2.14.1-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Chisel:2.15.0-GTNH:api") {transitive = false }
 
     compileOnly("com.github.GTNewHorizons:ZenScript:1.0.0-GTNH") {transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.3.1:dev") {transitive = false }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/TelepositionFocus.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/TelepositionFocus.java
@@ -8,9 +8,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-import net.minecraftforge.common.DimensionManager;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -75,7 +75,8 @@ public class TelepositionFocus extends EnergyItems {
     }
 
     public World getWorld(ItemStack itemStack) {
-        return DimensionManager.getWorld(getDimensionID(itemStack));
+        return FMLCommonHandler.instance().getMinecraftServerInstance()
+                .worldServerForDimension(getDimensionID(itemStack));
     }
 
     public int xCoord(ItemStack itemStack) {


### PR DESCRIPTION
`DimensionManger.getWorld()` will return null for certain dimensions if no chunks are being actively loaded.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16139