### PR TITLE
LP Hud fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,12 +24,12 @@
 
 dependencies {
     api("com.github.GTNewHorizons:waila:1.8.1:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.6.42-GTNH:dev")
     
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.68:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.44:dev") {transitive = false }
     
     compileOnly("com.github.GTNewHorizons:Botania:1.11.5-GTNH:api") {transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.10:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.16:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev") {transitive = false }
     
     compileOnly("com.github.GTNewHorizons:Chisel:2.15.2-GTNH:api") {transitive = false }

--- a/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
@@ -114,18 +114,20 @@ public class RenderHelper {
 
         ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
         GL11.glColor4f(1, 0, 0, 1.0F);
-        mc.getTextureManager().bindTexture(test2);
+		GL11.glEnable(3042);
+        mc.renderEngine.bindTexture(test2);
 
         GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
-
+		GL11.glPushMatrix();
         drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
-
+		GL11.glPopMatrix();
         ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        mc.getTextureManager().bindTexture(test);
-
+        mc.renderEngine.bindTexture(test);
+		GL11.glPushMatrix();
         drawTexturedModalRect(x, y, 0, 0, 256, 256);
-
+		GL11.glPopMatrix();
+		GL11.glDisable(3042);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
@@ -102,30 +102,30 @@ public class RenderHelper {
         return true;
     }
 
-	private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
-		GL11.glPushMatrix();
-		int xSize = 32;
-		int ySize = 32;
-		int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
-		int x = (lpBarX - xSize / 2) * 8;
-		int y = (lpBarY - ySize / 2) * 8;
-		ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
-		GL11.glColor4f(1, 0, 0, 1.0F);
-		GL11.glEnable(GL11.GL_BLEND);
-		mc.renderEngine.bindTexture(test2);
-		GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
-		GL11.glPushMatrix();
-		drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
-		GL11.glPopMatrix();
-		ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		mc.renderEngine.bindTexture(test);
-		GL11.glPushMatrix();
-		drawTexturedModalRect(x, y, 0, 0, 256, 256);
-		GL11.glPopMatrix();
-		GL11.glDisable(GL11.GL_BLEND);
-		GL11.glPopMatrix();
-	}
+    private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
+        GL11.glPushMatrix();
+        int xSize = 32;
+        int ySize = 32;
+        int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
+        int x = (lpBarX - xSize / 2) * 8;
+        int y = (lpBarY - ySize / 2) * 8;
+        ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
+        GL11.glColor4f(1, 0, 0, 1.0F);
+        GL11.glEnable(GL11.GL_BLEND);
+        mc.renderEngine.bindTexture(test2);
+        GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
+        GL11.glPushMatrix();
+        drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
+        GL11.glPopMatrix();
+        ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        mc.renderEngine.bindTexture(test);
+        GL11.glPushMatrix();
+        drawTexturedModalRect(x, y, 0, 0, 256, 256);
+        GL11.glPopMatrix();
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glPopMatrix();
+    }
 
     private static void renderHPHUD(Minecraft mc, float hpAmount, float maxAmount) {
         GL11.glPushMatrix();

--- a/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
@@ -102,30 +102,30 @@ public class RenderHelper {
         return true;
     }
 
-private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
-	GL11.glPushMatrix();
-	int xSize = 32;
-	int ySize = 32;
-	int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
-	int x = (lpBarX - xSize / 2) * 8;
-	int y = (lpBarY - ySize / 2) * 8;
-	ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
-	GL11.glColor4f(1, 0, 0, 1.0F);
-	GL11.glEnable(GL11.GL_BLEND);
-	mc.renderEngine.bindTexture(test2);
-	GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
-	GL11.glPushMatrix();
-	drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
-	GL11.glPopMatrix();
-	ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
-	GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-	mc.renderEngine.bindTexture(test);
-	GL11.glPushMatrix();
-	drawTexturedModalRect(x, y, 0, 0, 256, 256);
-	GL11.glPopMatrix();
-	GL11.glDisable(GL11.GL_BLEND);
-	GL11.glPopMatrix();
-}
+	private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
+		GL11.glPushMatrix();
+		int xSize = 32;
+		int ySize = 32;
+		int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
+		int x = (lpBarX - xSize / 2) * 8;
+		int y = (lpBarY - ySize / 2) * 8;
+		ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
+		GL11.glColor4f(1, 0, 0, 1.0F);
+		GL11.glEnable(GL11.GL_BLEND);
+		mc.renderEngine.bindTexture(test2);
+		GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
+		GL11.glPushMatrix();
+		drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
+		GL11.glPopMatrix();
+		ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
+		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		mc.renderEngine.bindTexture(test);
+		GL11.glPushMatrix();
+		drawTexturedModalRect(x, y, 0, 0, 256, 256);
+		GL11.glPopMatrix();
+		GL11.glDisable(GL11.GL_BLEND);
+		GL11.glPopMatrix();
+	}
 
     private static void renderHPHUD(Minecraft mc, float hpAmount, float maxAmount) {
         GL11.glPushMatrix();

--- a/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/renderer/RenderHelper.java
@@ -102,34 +102,30 @@ public class RenderHelper {
         return true;
     }
 
-    private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
-        GL11.glPushMatrix();
-        int xSize = 32;
-        int ySize = 32;
-
-        int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
-
-        int x = (lpBarX - xSize / 2) * 8;
-        int y = (lpBarY - ySize / 2) * 8;
-
-        ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
-        GL11.glColor4f(1, 0, 0, 1.0F);
-		GL11.glEnable(3042);
-        mc.renderEngine.bindTexture(test2);
-
-        GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
-		GL11.glPushMatrix();
-        drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
-		GL11.glPopMatrix();
-        ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        mc.renderEngine.bindTexture(test);
-		GL11.glPushMatrix();
-        drawTexturedModalRect(x, y, 0, 0, 256, 256);
-		GL11.glPopMatrix();
-		GL11.glDisable(3042);
-        GL11.glPopMatrix();
-    }
+private static void renderLPHUD(Minecraft mc, int lpAmount, int maxAmount) {
+	GL11.glPushMatrix();
+	int xSize = 32;
+	int ySize = 32;
+	int amount = Math.max((int) (256 * ((double) (maxAmount - lpAmount) / maxAmount)), 0);
+	int x = (lpBarX - xSize / 2) * 8;
+	int y = (lpBarY - ySize / 2) * 8;
+	ResourceLocation test2 = new ResourceLocation("alchemicalwizardry", "textures/gui/container1.png");
+	GL11.glColor4f(1, 0, 0, 1.0F);
+	GL11.glEnable(GL11.GL_BLEND);
+	mc.renderEngine.bindTexture(test2);
+	GL11.glScalef(1f / 8f, 1f / 8f, 1f / 8f);
+	GL11.glPushMatrix();
+	drawTexturedModalRect(x, y + amount, 0, amount, 256, 256 - amount);
+	GL11.glPopMatrix();
+	ResourceLocation test = new ResourceLocation("alchemicalwizardry", "textures/gui/lpVial.png");
+	GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+	mc.renderEngine.bindTexture(test);
+	GL11.glPushMatrix();
+	drawTexturedModalRect(x, y, 0, 0, 256, 256);
+	GL11.glPopMatrix();
+	GL11.glDisable(GL11.GL_BLEND);
+	GL11.glPopMatrix();
+}
 
     private static void renderHPHUD(Minecraft mc, float hpAmount, float maxAmount) {
         GL11.glPushMatrix();


### PR DESCRIPTION

fix lp hud with waila and botania when targeting a block like grass and with mana bar present.
I took the hud code of the Thaumcraft sanity checker as a reference.

this is the bug before the commit:
![Senzanome](https://github.com/user-attachments/assets/3938d804-4443-4f94-8c4a-2e7d2525de6a)

after: fixed!
