### PR TITLE
Readd Meteor Filler

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -78,6 +78,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 }
 
                 List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
+                sortedFiller.sort(Comparator.comparingInt(c -> -c.getWeight()));
                 float totalFillerWeight = meteor.getTotalListWeight(meteor.fillerList);
 
                 for (MeteorParadigmComponent filler : sortedFiller) {

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -162,6 +162,9 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             if (meteor.componentList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
                 arecipes.add(new CachedMeteorRecipe(meteor, result));
             }
+            if (meteor.fillerList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
+                arecipes.add(new CachedMeteorRecipe(meteor, result));
+            }
         }
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -73,13 +73,13 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 }
             }
 
-            List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
-
             if (fillerChance > 0) {
                 if (col != 0) {
                     col = 0;
                     row++;
                 }
+
+                List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
 
                 if (!sortedFiller.isEmpty()) {
                     sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -42,7 +42,6 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int col = 0;
 
             float totalComponentWeight = meteor.getTotalListWeight(meteor.componentList);
-            float totalFillerWeight = meteor.getTotalListWeight(meteor.fillerList);
             int fillerChance = meteor.fillerChance;
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getWeight()));
@@ -79,6 +78,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 }
 
                 List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
+                float totalFillerWeight = meteor.getTotalListWeight(meteor.fillerList);
 
                 for (MeteorParadigmComponent filler : sortedFiller) {
                     ItemStack stack = filler.getValidBlockParadigm();

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -54,7 +54,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                float chance = component.getChance() / totalComponentWeight * (float)(1 - fillerChance / 100.0);
+                float chance = component.getChance() / totalComponentWeight * (float) (1 - fillerChance / 100.0);
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                 this.outputs.add(new TooltipStack(stack, xPos, yPos, tooltips));

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -46,7 +46,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             float totalFillerWeight = meteor.getTotalFillerWeight();
             int fillerChance = meteor.fillerChance;
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
-            sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
+            sortedComponents.sort(Comparator.comparingInt(c -> -c.getWeight()));
 
             float fillerRatio = (float) (fillerChance / 100.0);
             float componentRatio = 1 - fillerRatio;
@@ -57,7 +57,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                float chance = component.getChance() / totalComponentWeight * componentRatio;
+                float chance = component.getWeight() / totalComponentWeight * componentRatio;
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                 this.outputs.add(new TooltipStack(stack, xPos, yPos, tooltips));
@@ -82,7 +82,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
 
                 if (!sortedFiller.isEmpty()) {
-                    sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));
+                    sortedFiller.sort(Comparator.comparingInt(c -> -c.getWeight()));
                 } else {
                     sortedFiller.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
                     totalFillerWeight = 1;
@@ -94,7 +94,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                     int yPos = 37 + 18 * row;
 
                     List<String> tooltips = new ArrayList<>();
-                    float chance = filler.getChance() / totalFillerWeight * fillerRatio;
+                    float chance = filler.getWeight() / totalFillerWeight * fillerRatio;
                     tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                     tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                     tooltips.add(I18n.format("nei.recipe.meteor.filler"));

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -42,8 +41,8 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int row = 0;
             int col = 0;
 
-            float totalComponentWeight = meteor.getTotalComponentWeight();
-            float totalFillerWeight = meteor.getTotalFillerWeight();
+            float totalComponentWeight = meteor.getTotalListWeight(meteor.componentList);
+            float totalFillerWeight = meteor.getTotalListWeight(meteor.fillerList);
             int fillerChance = meteor.fillerChance;
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getWeight()));
@@ -80,13 +79,6 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 }
 
                 List<MeteorParadigmComponent> sortedFiller = new ArrayList<>(meteor.fillerList);
-
-                if (!sortedFiller.isEmpty()) {
-                    sortedFiller.sort(Comparator.comparingInt(c -> -c.getWeight()));
-                } else {
-                    sortedFiller.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
-                    totalFillerWeight = 1;
-                }
 
                 for (MeteorParadigmComponent filler : sortedFiller) {
                     ItemStack stack = filler.getValidBlockParadigm();

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -9,7 +9,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
@@ -44,11 +43,8 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int col = 0;
 
             float totalComponentWeight = meteor.getTotalComponentWeight();
-            System.out.println("totalComponentWeight: " +totalComponentWeight);
             float totalFillerWeight = meteor.getTotalFillerWeight();
-            System.out.println("totalFilerWeight: " + totalFillerWeight);
             int fillerChance = meteor.fillerChance;
-            System.out.println("fillerChance: " + fillerChance);
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
@@ -58,9 +54,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                float chance = component.getChance() / totalComponentWeight * (float)(1 - fillerChance /100.0);
-                System.out.println("block: " + stack.toString());
-                System.out.println("chance: " + chance);
+                float chance = component.getChance() / totalComponentWeight * (float)(1 - fillerChance / 100.0);
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                 this.outputs.add(new TooltipStack(stack, xPos, yPos, tooltips));
@@ -84,9 +78,9 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                     row++;
                 }
 
-                sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));
-
-                if (sortedFiller.isEmpty()) {
+                if (!sortedFiller.isEmpty()) {
+                    sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));
+                } else {
                     sortedFiller.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
                     totalFillerWeight = 1;
                 }

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -48,13 +48,16 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
+            float fillerRatio = (float) (fillerChance / 100.0);
+            float componentRatio = 1 - fillerRatio;
+
             for (MeteorParadigmComponent component : sortedComponents) {
                 ItemStack stack = component.getValidBlockParadigm();
                 int xPos = 3 + 18 * col;
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                float chance = component.getChance() / totalComponentWeight * (float) (1 - fillerChance / 100.0);
+                float chance = component.getChance() / totalComponentWeight * componentRatio;
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                 this.outputs.add(new TooltipStack(stack, xPos, yPos, tooltips));
@@ -91,7 +94,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                     int yPos = 37 + 18 * row;
 
                     List<String> tooltips = new ArrayList<>();
-                    float chance = filler.getChance() / totalFillerWeight * (float) (fillerChance / 100.0);
+                    float chance = filler.getChance() / totalFillerWeight * fillerRatio;
                     tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                     tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                     tooltips.add(I18n.format("nei.recipe.meteor.filler"));

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -40,8 +40,8 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int row = 0;
             int col = 0;
 
-            float totalMeteorWeight = meteor.getTotalMeteorWeight();
-            List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
+            float totalMeteorWeight = meteor.getTotalOreWeight();
+            List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.oreList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
             for (MeteorParadigmComponent component : sortedComponents) {
@@ -112,7 +112,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
     @Override
     public void loadCraftingRecipes(ItemStack result) {
         for (MeteorParadigm meteor : getSortedMeteors()) {
-            if (meteor.componentList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
+            if (meteor.oreList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
                 arecipes.add(new CachedMeteorRecipe(meteor, result));
             }
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -15,12 +15,12 @@ import cpw.mods.fml.common.registry.GameRegistry;
 
 public class Meteor {
 
-    public String[] ores;
-    public int radius;
-    public int cost;
-    public String focusModId;
-    public String focusName;
-    public int focusMeta;
+    private String[] ores;
+    private int radius;
+    private int cost;
+    private String focusModId;
+    private String focusName;
+    private int focusMeta;
     private String[] filler;
     private int fillerChance;
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.util.Arrays;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.MalformedJsonException;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
@@ -41,7 +43,7 @@ public class Meteor {
                             m.filler,
                             m.fillerChance);
                 }
-            } catch (FileNotFoundException e) {
+            } catch (FileNotFoundException | JsonSyntaxException e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -41,9 +41,6 @@ public class Meteor {
                             m.cost,
                             m.filler,
                             m.fillerChance);
-                    System.out.println("ores: " + Arrays.toString(m.ores));
-                    System.out.println("filler: " + Arrays.toString(m.filler));
-                    System.out.println("fillerChance: " + m.fillerChance);
                 }
             } catch (FileNotFoundException e) {
                 e.printStackTrace();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -5,13 +5,12 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.stream.MalformedJsonException;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.Arrays;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -21,6 +22,8 @@ public class Meteor {
     public String focusModId;
     public String focusName;
     public int focusMeta;
+    private String[] filler;
+    private int fillerChance;
 
     public static void loadConfig() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -35,7 +38,12 @@ public class Meteor {
                             findItemStack(m.focusModId, m.focusName, m.focusMeta),
                             m.ores,
                             m.radius,
-                            m.cost);
+                            m.cost,
+                            m.filler,
+                            m.fillerChance);
+                    System.out.println("ores: " + Arrays.toString(m.ores));
+                    System.out.println("filler: " + Arrays.toString(m.filler));
+                    System.out.println("fillerChance: " + m.fillerChance);
                 }
             } catch (FileNotFoundException e) {
                 e.printStackTrace();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -133,7 +133,7 @@ public class MeteorParadigm {
             fillerChance *= 1.12;
         } else if (hasTerrae) {
             newRadius += 1;
-            fillerChance *= 1.6;
+            fillerChance *= 1.06;
         }
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -45,12 +45,8 @@ public class MeteorParadigm {
     // OREDICT:oreDictName:weight
     private static final Pattern oredictPattern = Pattern.compile("OREDICT:(.*):(\\d+)");
 
-    public void parseStringArray(String[] componentArray) {
-        parseStringArray(componentArray, false);
-    }
-
-    public void parseStringArray(String[] blockArray, boolean filler) {
-        List<MeteorParadigmComponent> addList = filler ? fillerList : componentList;
+    public static List<MeteorParadigmComponent> parseStringArray(String[] blockArray) {
+        List<MeteorParadigmComponent> addList = new ArrayList<>();
         for (int i = 0; i < blockArray.length; ++i) {
             String blockName = blockArray[i];
             boolean success = false;
@@ -101,6 +97,7 @@ public class MeteorParadigm {
                 AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + blockName + "\"");
             }
         }
+        return addList;
     }
 
     public int getTotalListWeight(List<MeteorParadigmComponent> blockList) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -135,6 +135,9 @@ public class MeteorParadigm {
             newRadius += 1;
             fillerChance *= 1.06;
         }
+        if (fillerChance > 100) {
+            fillerChance = 100;
+        }
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -103,17 +103,9 @@ public class MeteorParadigm {
         }
     }
 
-    public int getTotalComponentWeight() {
+    public int getTotalListWeight(List<MeteorParadigmComponent> blockList) {
         int totalWeight = 0;
-        for (MeteorParadigmComponent mpc : componentList) {
-            totalWeight += mpc.getWeight();
-        }
-        return totalWeight;
-    }
-
-    public int getTotalFillerWeight() {
-        int totalWeight = 0;
-        for (MeteorParadigmComponent mpc : fillerList) {
+        for (MeteorParadigmComponent mpc : blockList) {
             totalWeight += mpc.getWeight();
         }
         return totalWeight;
@@ -144,6 +136,8 @@ public class MeteorParadigm {
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);
 
+        List<MeteorParadigmComponent> fillerList = new ArrayList<>();
+
         if (hasCrystallos || hasIncendium || hasTennebrae) {
             fillerList = new ArrayList<>();
             if (hasCrystallos) {
@@ -157,10 +151,12 @@ public class MeteorParadigm {
             if (hasTennebrae) {
                 fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.obsidian), 180));
             }
+        } else {
+            fillerList = this.fillerList;
         }
 
-        int totalComponentWeight = getTotalComponentWeight();
-        int totalFillerWeight = getTotalFillerWeight();
+        int totalComponentWeight = getTotalListWeight(componentList);
+        int totalFillerWeight = getTotalListWeight(fillerList);
 
         for (int i = -newRadius; i <= newRadius; i++) {
             for (int j = -newRadius; j <= newRadius; j++) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -49,13 +49,13 @@ public class MeteorParadigm {
         parseStringArray(componentArray, false);
     }
 
-    public void parseStringArray(String[] componentArray, boolean filler) {
+    public void parseStringArray(String[] blockArray, boolean filler) {
         List<MeteorParadigmComponent> addList = filler ? fillerList : componentList;
-        for (int i = 0; i < componentArray.length; ++i) {
-            String componentName = componentArray[i];
+        for (int i = 0; i < blockArray.length; ++i) {
+            String blockName = blockArray[i];
             boolean success = false;
 
-            Matcher matcher = itemNamePattern.matcher(componentName);
+            Matcher matcher = itemNamePattern.matcher(blockName);
             if (matcher.matches()) {
                 String modID = matcher.group(1);
                 String itemName = matcher.group(2);
@@ -69,7 +69,7 @@ public class MeteorParadigm {
                     success = true;
                 }
 
-            } else if ((matcher = oredictPattern.matcher(componentName)).matches()) {
+            } else if ((matcher = oredictPattern.matcher(blockName)).matches()) {
                 String oreDict = matcher.group(1);
                 int weight = Integer.parseInt(matcher.group(2));
 
@@ -84,8 +84,8 @@ public class MeteorParadigm {
 
             } else {
                 // Legacy config
-                String oreDict = componentName;
-                int weight = Integer.parseInt(componentArray[++i]);
+                String oreDict = blockName;
+                int weight = Integer.parseInt(blockArray[++i]);
 
                 List<ItemStack> list = OreDictionary.getOres(oreDict);
                 for (ItemStack stack : list) {
@@ -98,7 +98,7 @@ public class MeteorParadigm {
             }
 
             if (!success) {
-                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + componentName + "\"");
+                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + blockName + "\"");
             }
         }
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -20,7 +20,7 @@ import gregtech.common.blocks.TileEntityOres;
 
 public class MeteorParadigm {
 
-    public List<MeteorParadigmComponent> oreList = new ArrayList<>();
+    public List<MeteorParadigmComponent> componentList = new ArrayList<>();
     public List<MeteorParadigmComponent> fillerList = new ArrayList<>();
     public ItemStack focusStack;
     public int radius;
@@ -45,17 +45,17 @@ public class MeteorParadigm {
     // OREDICT:oreDictName:weight
     private static final Pattern oredictPattern = Pattern.compile("OREDICT:(.*):(\\d+)");
 
-    public void parseStringArray(String[] oreArray) {
-        parseStringArray(oreArray, false);
+    public void parseStringArray(String[] componentArray) {
+        parseStringArray(componentArray, false);
     }
 
-    public void parseStringArray(String[] oreArray, boolean filler) {
-        List<MeteorParadigmComponent> addList = filler ? fillerList : oreList;
-        for (int i = 0; i < oreArray.length; ++i) {
-            String oreName = oreArray[i];
+    public void parseStringArray(String[] componentArray, boolean filler) {
+        List<MeteorParadigmComponent> addList = filler ? fillerList : componentList;
+        for (int i = 0; i < componentArray.length; ++i) {
+            String componentName = componentArray[i];
             boolean success = false;
 
-            Matcher matcher = itemNamePattern.matcher(oreName);
+            Matcher matcher = itemNamePattern.matcher(componentName);
             if (matcher.matches()) {
                 String modID = matcher.group(1);
                 String itemName = matcher.group(2);
@@ -69,7 +69,7 @@ public class MeteorParadigm {
                     success = true;
                 }
 
-            } else if ((matcher = oredictPattern.matcher(oreName)).matches()) {
+            } else if ((matcher = oredictPattern.matcher(componentName)).matches()) {
                 String oreDict = matcher.group(1);
                 int weight = Integer.parseInt(matcher.group(2));
 
@@ -84,8 +84,8 @@ public class MeteorParadigm {
 
             } else {
                 // Legacy config
-                String oreDict = oreName;
-                int weight = Integer.parseInt(oreArray[++i]);
+                String oreDict = componentName;
+                int weight = Integer.parseInt(componentArray[++i]);
 
                 List<ItemStack> list = OreDictionary.getOres(oreDict);
                 for (ItemStack stack : list) {
@@ -98,14 +98,14 @@ public class MeteorParadigm {
             }
 
             if (!success) {
-                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + oreName + "\"");
+                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + componentName + "\"");
             }
         }
     }
 
-    public int getTotalOreWeight() {
+    public int getTotalComponentWeight() {
         int totalWeight = 0;
-        for (MeteorParadigmComponent mpc : oreList) {
+        for (MeteorParadigmComponent mpc : componentList) {
             totalWeight += mpc.getChance();
         }
         return totalWeight;
@@ -150,7 +150,7 @@ public class MeteorParadigm {
 
         float totalChance = iceChance + soulChance + obsidChance;
 
-        int totalOreWeight = getTotalOreWeight();
+        int totalComponentWeight = getTotalComponentWeight();
         int totalFillerWeight = getTotalFillerWeight();
 
         for (int i = -newRadius; i <= newRadius; i++) {
@@ -165,7 +165,7 @@ public class MeteorParadigm {
                     }
 
                     if (world.rand.nextInt(100) >= fillerChance) {
-                        setMeteorBlock(x + i, y + j, z + k, world, oreList, totalOreWeight);
+                        setMeteorBlock(x + i, y + j, z + k, world, componentList, totalComponentWeight);
                     } else {
                         float randChance = rand.nextFloat() * totalChance;
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -25,12 +25,12 @@ public class MeteorParadigm {
     public ItemStack focusStack;
     public int radius;
     public int cost;
-    public int fillerChance; //Out of 100
+    public int fillerChance; // Out of 100
 
     public static Random rand = new Random();
 
     public MeteorParadigm(ItemStack focusStack, int radius, int cost) {
-        new MeteorParadigm(focusStack, radius, cost ,0);
+        new MeteorParadigm(focusStack, radius, cost, 0);
     }
 
     public MeteorParadigm(ItemStack focusStack, int radius, int cost, int fillerWeight) {
@@ -206,7 +206,8 @@ public class MeteorParadigm {
         }
     }
 
-    private void setMeteorBlock(int x, int y, int z, World world, List<MeteorParadigmComponent> blockList, int totalListWeight) {
+    private void setMeteorBlock(int x, int y, int z, World world, List<MeteorParadigmComponent> blockList,
+            int totalListWeight) {
         int randNum = world.rand.nextInt(totalListWeight);
         for (MeteorParadigmComponent mpc : blockList) {
             randNum -= mpc.getChance();
@@ -214,20 +215,9 @@ public class MeteorParadigm {
             if (randNum < 0) {
                 ItemStack blockStack = mpc.getValidBlockParadigm();
                 if (blockStack != null && blockStack.getItem() instanceof ItemBlock) {
-                    ((ItemBlock) blockStack.getItem()).placeBlockAt(
-                            blockStack,
-                            null,
-                            world,
-                            x,
-                            y,
-                            z,
-                            0,
-                            0,
-                            0,
-                            0,
-                            blockStack.getItemDamage());
-                    if (AlchemicalWizardry.isGregTechLoaded)
-                        setGTOresNaturalIfNeeded(world, x, y, z);
+                    ((ItemBlock) blockStack.getItem())
+                            .placeBlockAt(blockStack, null, world, x, y, z, 0, 0, 0, 0, blockStack.getItemDamage());
+                    if (AlchemicalWizardry.isGregTechLoaded) setGTOresNaturalIfNeeded(world, x, y, z);
                     world.markBlockForUpdate(x, y, z);
                     break;
                 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -136,7 +136,7 @@ public class MeteorParadigm {
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);
 
-        List<MeteorParadigmComponent> fillerList = new ArrayList<>();
+        List<MeteorParadigmComponent> fillerList;
 
         if (hasCrystallos || hasIncendium || hasTennebrae) {
             fillerList = new ArrayList<>();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -33,11 +33,11 @@ public class MeteorParadigm {
         new MeteorParadigm(focusStack, radius, cost, 0);
     }
 
-    public MeteorParadigm(ItemStack focusStack, int radius, int cost, int fillerWeight) {
+    public MeteorParadigm(ItemStack focusStack, int radius, int cost, int fillerChance) {
         this.focusStack = focusStack;
         this.radius = radius;
         this.cost = cost;
-        this.fillerChance = fillerWeight;
+        this.fillerChance = fillerChance;
     }
 
     // modId:itemName:meta:weight

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -1,7 +1,6 @@
 package WayofTime.alchemicalWizardry.common.summoning.meteor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.regex.Matcher;
@@ -18,7 +17,6 @@ import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.common.blocks.TileEntityOres;
-import org.lwjgl.Sys;
 
 public class MeteorParadigm {
 
@@ -211,9 +209,6 @@ public class MeteorParadigm {
     private void setMeteorBlock(int x, int y, int z, World world, List<MeteorParadigmComponent> blockList, int totalListWeight) {
         int randNum = world.rand.nextInt(totalListWeight);
         for (MeteorParadigmComponent mpc : blockList) {
-            System.out.println("block: " + mpc.getValidBlockParadigm());
-            System.out.println("chance: " + mpc.getChance());
-            System.out.println("randNum: " + randNum);
             randNum -= mpc.getChance();
 
             if (randNum < 0) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -106,7 +106,7 @@ public class MeteorParadigm {
     public int getTotalComponentWeight() {
         int totalWeight = 0;
         for (MeteorParadigmComponent mpc : componentList) {
-            totalWeight += mpc.getChance();
+            totalWeight += mpc.getWeight();
         }
         return totalWeight;
     }
@@ -114,7 +114,7 @@ public class MeteorParadigm {
     public int getTotalFillerWeight() {
         int totalWeight = 0;
         for (MeteorParadigmComponent mpc : fillerList) {
-            totalWeight += mpc.getChance();
+            totalWeight += mpc.getWeight();
         }
         return totalWeight;
     }
@@ -144,11 +144,20 @@ public class MeteorParadigm {
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);
 
-        float iceChance = hasCrystallos ? 1 : 0;
-        float soulChance = hasIncendium ? 1 : 0;
-        float obsidChance = hasTennebrae ? 1 : 0;
-
-        float totalChance = iceChance + soulChance + obsidChance;
+        if (hasCrystallos || hasIncendium || hasTennebrae) {
+            fillerList = new ArrayList<>();
+            if (hasCrystallos) {
+                fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.ice), 180)); // 180 = 2^2 * 3^2 * 5
+            }
+            if (hasIncendium) {
+                fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.netherrack), 60));
+                fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.soul_sand), 60));
+                fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.glowstone), 60));
+            }
+            if (hasTennebrae) {
+                fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.obsidian), 180));
+            }
+        }
 
         int totalComponentWeight = getTotalComponentWeight();
         int totalFillerWeight = getTotalFillerWeight();
@@ -167,39 +176,7 @@ public class MeteorParadigm {
                     if (fillerChance <= 0 || world.rand.nextInt(100) >= fillerChance) {
                         setMeteorBlock(x + i, y + j, z + k, world, componentList, totalComponentWeight);
                     } else {
-                        float randChance = rand.nextFloat() * totalChance;
-
-                        if (randChance < iceChance) {
-                            world.setBlock(x + i, y + j, z + k, Blocks.ice, 0, 3);
-                        } else {
-                            randChance -= iceChance;
-
-                            if (randChance < soulChance) {
-                                switch (rand.nextInt(3)) {
-                                    case 0:
-                                        world.setBlock(x + i, y + j, z + k, Blocks.soul_sand, 0, 3);
-                                        break;
-                                    case 1:
-                                        world.setBlock(x + i, y + j, z + k, Blocks.glowstone, 0, 3);
-                                        break;
-                                    case 2:
-                                        world.setBlock(x + i, y + j, z + k, Blocks.netherrack, 0, 3);
-                                        break;
-                                }
-                            } else {
-                                randChance -= soulChance;
-
-                                if (randChance < obsidChance) {
-                                    world.setBlock(x + i, y + j, z + k, Blocks.obsidian, 0, 3);
-                                } else {
-                                    if (!this.fillerList.isEmpty()) {
-                                        setMeteorBlock(x + i, y + j, z + k, world, fillerList, totalFillerWeight);
-                                    } else {
-                                        world.setBlock(x + i, y + j, z + k, Blocks.stone, 0, 3);
-                                    }
-                                }
-                            }
-                        }
+                        setMeteorBlock(x + i, y + j, z + k, world, fillerList, totalFillerWeight);
                     }
                 }
             }
@@ -210,7 +187,7 @@ public class MeteorParadigm {
             int totalListWeight) {
         int randNum = world.rand.nextInt(totalListWeight);
         for (MeteorParadigmComponent mpc : blockList) {
-            randNum -= mpc.getChance();
+            randNum -= mpc.getWeight();
 
             if (randNum < 0) {
                 ItemStack blockStack = mpc.getValidBlockParadigm();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -194,7 +194,7 @@ public class MeteorParadigm {
                                 if (randChance < obsidChance) {
                                     world.setBlock(x + i, y + j, z + k, Blocks.obsidian, 0, 3);
                                 } else {
-                                    if (this.fillerList != null) {
+                                    if (!this.fillerList.isEmpty()) {
                                         setMeteorBlock(x + i, y + j, z + k, world, fillerList, totalFillerWeight);
                                     } else {
                                         world.setBlock(x + i, y + j, z + k, Blocks.stone, 0, 3);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -128,10 +128,13 @@ public class MeteorParadigm {
 
         int newRadius = radius;
 
+        int fillerChance = this.fillerChance;
         if (hasOrbisTerrae) {
             newRadius += 2;
+            fillerChance *= 1.12;
         } else if (hasTerrae) {
             newRadius += 1;
+            fillerChance *= 1.6;
         }
 
         world.createExplosion(null, x, y, z, newRadius * 4, AlchemicalWizardry.doMeteorsDestroyBlocks);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -164,7 +164,7 @@ public class MeteorParadigm {
                         continue;
                     }
 
-                    if (world.rand.nextInt(100) >= fillerChance) {
+                    if (fillerChance <= 0 || world.rand.nextInt(100) >= fillerChance) {
                         setMeteorBlock(x + i, y + j, z + k, world, componentList, totalComponentWeight);
                     } else {
                         float randChance = rand.nextFloat() * totalChance;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -127,7 +127,6 @@ public class MeteorParadigm {
         }
 
         int newRadius = radius;
-
         int fillerChance = this.fillerChance;
         if (hasOrbisTerrae) {
             newRadius += 2;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigmComponent.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigmComponent.java
@@ -4,16 +4,16 @@ import net.minecraft.item.ItemStack;
 
 public class MeteorParadigmComponent {
 
-    protected int chance;
+    protected int weight;
     protected ItemStack itemStack;
 
-    public MeteorParadigmComponent(ItemStack stack, int chance) {
+    public MeteorParadigmComponent(ItemStack stack, int weight) {
         this.itemStack = stack;
-        this.chance = chance;
+        this.weight = weight;
     }
 
-    public int getChance() {
-        return this.chance;
+    public int getWeight() {
+        return this.weight;
     }
 
     public ItemStack getValidBlockParadigm() {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -25,7 +25,7 @@ public class MeteorRegistry {
         if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(componentList);
-            if (fillerChance > 0 && fillerList != null && fillerList.length > 0) {
+            if (fillerList != null && fillerList.length > 0) {
                 meteor.parseStringArray(fillerList, true);
             } else {
                 meteor.fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -24,9 +24,9 @@ public class MeteorRegistry {
             String[] fillerList, int fillerChance) {
         if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
-            meteor.parseStringArray(componentList);
+            meteor.componentList = MeteorParadigm.parseStringArray(componentList);
             if (fillerList != null && fillerList.length > 0) {
-                meteor.parseStringArray(fillerList, true);
+                meteor.fillerList = MeteorParadigm.parseStringArray(fillerList);
             } else {
                 meteor.fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -15,14 +15,14 @@ public class MeteorRegistry {
         paradigmList.add(paradigm);
     }
 
-    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost) {
-        registerMeteorParadigm(stack, oreList, radius, cost, null, 0);
+    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost) {
+        registerMeteorParadigm(stack, componentList, radius, cost, null, 0);
     }
 
-    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost, String[] fillerList, int fillerChance) {
-        if (stack != null && oreList != null) {
+    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost, String[] fillerList, int fillerChance) {
+        if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
-            meteor.parseStringArray(oreList);
+            meteor.parseStringArray(componentList);
             if (fillerList != null) {
                 meteor.parseStringArray(fillerList, true);
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -25,7 +25,7 @@ public class MeteorRegistry {
         if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(componentList);
-            if (fillerChance > 0 && fillerList != null) {
+            if (fillerChance > 0 && fillerList != null && fillerList.length > 0) {
                 meteor.parseStringArray(fillerList, true);
             } else {
                 meteor.fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -16,9 +16,16 @@ public class MeteorRegistry {
     }
 
     public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost) {
+        registerMeteorParadigm(stack, oreList, radius, cost, null, 0);
+    }
+
+    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost, String[] fillerList, int fillerChance) {
         if (stack != null && oreList != null) {
-            MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost);
+            MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(oreList);
+            if (fillerList != null) {
+                meteor.parseStringArray(fillerList, true);
+            }
             paradigmList.add(meteor);
         }
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -19,7 +19,8 @@ public class MeteorRegistry {
         registerMeteorParadigm(stack, componentList, radius, cost, null, 0);
     }
 
-    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost, String[] fillerList, int fillerChance) {
+    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost,
+            String[] fillerList, int fillerChance) {
         if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(componentList);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -3,6 +3,7 @@ package WayofTime.alchemicalWizardry.common.summoning.meteor;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
@@ -24,8 +25,10 @@ public class MeteorRegistry {
         if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(componentList);
-            if (fillerList != null) {
+            if (fillerChance > 0 && fillerList != null) {
                 meteor.parseStringArray(fillerList, true);
+            } else {
+                meteor.fillerList.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
             }
             paradigmList.add(meteor);
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -69,9 +69,9 @@ public class FallingTower {
 
         public Add(ItemStack stack, int radius, int cost, String[] components, String[] filler, int fillerChance) {
             paradigm = new MeteorParadigm(stack, radius, cost);
-            paradigm.parseStringArray(components);
+            paradigm.componentList = MeteorParadigm.parseStringArray(components);
             if (filler != null) {
-                paradigm.parseStringArray(filler, true);
+                paradigm.fillerList = MeteorParadigm.parseStringArray(filler);
             }
             paradigm.fillerChance = fillerChance;
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -42,6 +42,11 @@ public class FallingTower {
     }
 
     @ZenMethod
+    public static void addFocus(IItemStack stack, int radius, int cost, String components, String filler, int fillerChance) {
+        MineTweakerAPI.apply(new Add(toStack(stack), radius, cost, components.split("\\s*,\\s*"), filler.split("\\s*,\\s*"), fillerChance));
+    }
+
+    @ZenMethod
     public static void removeFocus(IItemStack output) {
         MineTweakerAPI.apply(new Remove(toStack(output)));
     }
@@ -50,9 +55,16 @@ public class FallingTower {
 
         private MeteorParadigm paradigm;
 
-        public Add(ItemStack stack, int radius, int cost, String[] components) {
+        public Add(ItemStack stack, int radius, int cost, String[] ores) {
+            new Add(stack, radius, cost, ores, null, 0);
+        }
+
+        public Add(ItemStack stack, int radius, int cost, String[] ores, String[] filler, int fillerChance) {
             paradigm = new MeteorParadigm(stack, radius, cost);
-            paradigm.parseStringArray(components);
+            paradigm.parseStringArray(ores);
+            if (filler != null) {
+                paradigm.parseStringArray(filler, true);
+            }
         }
 
         @Override

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -42,8 +42,16 @@ public class FallingTower {
     }
 
     @ZenMethod
-    public static void addFocus(IItemStack stack, int radius, int cost, String components, String filler, int fillerChance) {
-        MineTweakerAPI.apply(new Add(toStack(stack), radius, cost, components.split("\\s*,\\s*"), filler.split("\\s*,\\s*"), fillerChance));
+    public static void addFocus(IItemStack stack, int radius, int cost, String components, String filler,
+            int fillerChance) {
+        MineTweakerAPI.apply(
+                new Add(
+                        toStack(stack),
+                        radius,
+                        cost,
+                        components.split("\\s*,\\s*"),
+                        filler.split("\\s*,\\s*"),
+                        fillerChance));
     }
 
     @ZenMethod

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -55,13 +55,13 @@ public class FallingTower {
 
         private MeteorParadigm paradigm;
 
-        public Add(ItemStack stack, int radius, int cost, String[] ores) {
-            new Add(stack, radius, cost, ores, null, 0);
+        public Add(ItemStack stack, int radius, int cost, String[] components) {
+            new Add(stack, radius, cost, components, null, 0);
         }
 
-        public Add(ItemStack stack, int radius, int cost, String[] ores, String[] filler, int fillerChance) {
+        public Add(ItemStack stack, int radius, int cost, String[] components, String[] filler, int fillerChance) {
             paradigm = new MeteorParadigm(stack, radius, cost);
-            paradigm.parseStringArray(ores);
+            paradigm.parseStringArray(components);
             if (filler != null) {
                 paradigm.parseStringArray(filler, true);
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -65,6 +65,7 @@ public class FallingTower {
             if (filler != null) {
                 paradigm.parseStringArray(filler, true);
             }
+            paradigm.fillerChance = fillerChance;
         }
 
         @Override

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -268,6 +268,7 @@ nei.recipe.meteor.radius=Radius: %s
 nei.recipe.meteor.chance=Chance: %s%%
 nei.recipe.meteor.amount=Estimated amount: %s
 nei.recipe.meteor.filler=§7Filler block
+
 #Rituals
 ritual.AW001Water.name=Ritual of the Full Spring
 ritual.AW002Lava.name=Serenade of the Nether

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -267,7 +267,7 @@ nei.recipe.meteor.cost=Cost: %s LP
 nei.recipe.meteor.radius=Radius: %s
 nei.recipe.meteor.chance=Chance: %s%%
 nei.recipe.meteor.amount=Estimated amount: %s
-
+nei.recipe.meteor.filler=§7Filler block
 #Rituals
 ritual.AW001Water.name=Ritual of the Full Spring
 ritual.AW002Lava.name=Serenade of the Nether


### PR DESCRIPTION
Reimplement the concept of "filler" blocks to Blood Magic meteors.
Look for filler block list and fillerChance (chance for any individual block to be replaced with filler out of 100) in meteor config files in config/BloodMagic/meteors. Default filler block is minecraft:stone and default fillerChance is 0.
NEI meteor pages correctly show how much filler is expected in a meteor.
Fix an error in the block yield estimation function for more accurate results in NEI.