### PR TITLE
Fix ability to int overflow when adding to LP network

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -276,11 +276,11 @@ public class SoulNetworkHandler {
 
         int currEss = data.currentEssence;
 
-        if (currEss >= event.maximum || Integer.MAX_VALUE - event.addedAmount < currEss) {
+        if (currEss >= event.maximum) {
             return 0;
         }
 
-        int newEss = Math.min(event.maximum, currEss + event.addedAmount);
+        int newEss = (int) Math.min(Integer.MAX_VALUE, Math.min(event.maximum, (long) currEss + event.addedAmount));
         if (event.getResult() != Event.Result.DENY) {
             data.currentEssence = newEss;
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -276,7 +276,7 @@ public class SoulNetworkHandler {
 
         int currEss = data.currentEssence;
 
-        if (currEss >= event.maximum) {
+        if (currEss >= event.maximum || Integer.MAX_VALUE - event.addedAmount < currEss) {
             return 0;
         }
 


### PR DESCRIPTION
Tested with an altar pushing the orb above int-max LP, altar stopped increasing LP at int-max.
![image](https://github.com/user-attachments/assets/ef82f606-810d-48db-9eaf-b90df31cd052)

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16398