### PR TITLE
Config to Allow Altar Components to be Any Block

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -665,10 +665,19 @@ public class BloodMagicConfiguration {
                         new BlockStack(ModBlocks.bloodRune, 6) });
         AlchemicalWizardry.specialAltarBlock = getAltarRunesForTier(
                 "specialBlocks",
-                new BlockStack[] { new BlockStack(Blocks.stonebrick, 0), new BlockStack(Blocks.glowstone, 0),
-                        new BlockStack(Blocks.stonebrick, 0), new BlockStack(ModBlocks.largeBloodStoneBrick, 0),
-                        new BlockStack(Blocks.beacon, 0), new BlockStack(Blocks.stonebrick, 0),
-                        new BlockStack(ModBlocks.blockCrystal, 0) });
+                new BlockStack[] { new BlockStack(Blocks.air, 0), new BlockStack(Blocks.glowstone, 0),
+                        new BlockStack(Blocks.air, 0), new BlockStack(ModBlocks.largeBloodStoneBrick, 0),
+                        new BlockStack(Blocks.beacon, 0), new BlockStack(Blocks.air, 0),
+                        new BlockStack(ModBlocks.blockCrystal, 0) },
+                "Set the special blocks for the altar with the format mod:block(:meta) in the following order:\n"
+                        + "Tier 3 pillar\n"
+                        + "Tier 3 cap\n"
+                        + "Tier 4 pillar\n"
+                        + "Tier 4 cap\n"
+                        + "Tier 5 beacon\n"
+                        + "Tier 6 pillar\n"
+                        + "Tier 6 cap\n"
+                        + "Set any of these to minecraft:air to allow for that component to be any block EXCEPT air (e.g., let any block be used for a pillar).");
         config.save();
     }
 
@@ -808,12 +817,16 @@ public class BloodMagicConfiguration {
     }
 
     private static BlockStack[] getAltarRunesForTier(String tierName, BlockStack[] defaultValues) {
+        return getAltarRunesForTier(tierName, defaultValues, "");
+    }
+
+    private static BlockStack[] getAltarRunesForTier(String tierName, BlockStack[] defaultValues, String comment) {
         String[] defaultNames = new String[defaultValues.length];
         for (int i = 0; i < defaultValues.length; i++) {
             defaultNames[i] = Block.blockRegistry.getNameForObject(defaultValues[i].getBlock()) + ":"
                     + defaultValues[i].getMeta();
         }
-        Property property = config.get("rune overrides", tierName, defaultNames);
+        Property property = config.get("rune overrides", tierName, defaultNames, comment);
         String[] names = property.getStringList();
         if (names.length != defaultNames.length) {
             property.set(defaultNames);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
@@ -65,9 +66,15 @@ public class UpgradedAltars {
 
     private static boolean checkAltarComponent(AltarComponent altarComponent, IBlockAccess world, int x, int y, int z,
             int altarTier) {
-        Block block = world.getBlock(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
+        int compX = x + altarComponent.getX();
+        int compY = y + altarComponent.getY();
+        int compZ = z + altarComponent.getZ();
+        if (altarComponent.getBlock() == Blocks.air) {
+            return !world.isAirBlock(compX, compY, compZ);
+        }
+        Block block = world.getBlock(compX, compY, compZ);
         int metadata = world
-                .getBlockMetadata(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
+                .getBlockMetadata(compX, compY, compZ);
         if (altarComponent.isBloodRune()) {
             boolean result = false;
             BlockStack[] runes = getRuneOverrides(altarTier);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -73,8 +73,7 @@ public class UpgradedAltars {
             return !world.isAirBlock(compX, compY, compZ);
         }
         Block block = world.getBlock(compX, compY, compZ);
-        int metadata = world
-                .getBlockMetadata(compX, compY, compZ);
+        int metadata = world.getBlockMetadata(compX, compY, compZ);
         if (altarComponent.isBloodRune()) {
             boolean result = false;
             BlockStack[] runes = getRuneOverrides(altarTier);


### PR DESCRIPTION
Setting a value of minecraft:air in the specialBlocks config now allows for any non-air block to be used for that component. Pre-GTNH versions of Blood Magic allowed for any non-air block to be used for the pillars instead of only allowing for stone bricks (see glass blocks used in this guide https://ftbwiki.org/Blood_Altar#Upgrades). Default configs were changed to allow pillars to use this functionality. This change also allows for the pillar caps and beacons to be configured to act in the same way.

Air was chosen for this role in the config because air should never be a valid block for an altar component anyways.

Also improve the comment for that config option to explain this functionality and to show which values correspond to which altar component.