### PR TITLE
Add config to disable potion flask repairability

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -493,6 +493,7 @@ public class AlchemicalWizardry {
     public static boolean causeHungerWithRegen;
     public static boolean causeHungerChatMessage = true;
     public static boolean disableBoundToolsRightClick;
+    public static boolean allowPotionRepair;
 
     public static BlockStack[] secondTierRunes = new BlockStack[10];
     public static BlockStack[] thirdTierRunes = new BlockStack[10];

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -131,7 +131,7 @@ public class BloodMagicConfiguration {
                 .getBoolean();
         AlchemicalWizardry.causeHungerChatMessage = config.get("WimpySettings", "causeHungerChatMessage", true)
                 .getBoolean();
-        AlchemicalWizardry.allowPotionRepair = config.get("WimpySettings", "allowPotionRepair", false).getBoolean();
+        AlchemicalWizardry.allowPotionRepair = config.get("WimpySettings", "allowPotionRepair", true).getBoolean();
         // AlchemicalWizardry.lockdownAltar = config.get("WimpySettings", "LockdownAltarWithRegen", true).getBoolean();
         AlchemicalWizardry.lockdownAltar = false;
         AlchemicalWizardry.disableBoundToolsRightClick = config

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -131,6 +131,7 @@ public class BloodMagicConfiguration {
                 .getBoolean();
         AlchemicalWizardry.causeHungerChatMessage = config.get("WimpySettings", "causeHungerChatMessage", true)
                 .getBoolean();
+        AlchemicalWizardry.allowPotionRepair = config.get("WimpySettings", "allowPotionRepair", false).getBoolean();
         // AlchemicalWizardry.lockdownAltar = config.get("WimpySettings", "LockdownAltarWithRegen", true).getBoolean();
         AlchemicalWizardry.lockdownAltar = false;
         AlchemicalWizardry.disableBoundToolsRightClick = config

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/potion/AlchemyFlask.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/potion/AlchemyFlask.java
@@ -1,5 +1,7 @@
 package WayofTime.alchemicalWizardry.common.items.potion;
 
+import static WayofTime.alchemicalWizardry.AlchemicalWizardry.allowPotionRepair;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -346,5 +348,11 @@ public class AlchemyFlask extends Item {
         }
         potionStack.getTagCompound().setTag("CustomPotionEffects", nbttaglist);
         return new EntityPotion(worldObj, entityLivingBase, potionStack);
+    }
+
+    @Override
+    public boolean isRepairable() {
+        if (allowPotionRepair) return super.isRepairable();
+        return false;
     }
 }


### PR DESCRIPTION
Prevents _certain unintended interactions_ :tootroll:

Added as a config in case other packs or addons are relying on this bug