### PR TITLE
Enable Jabel and Generic Injection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,11 +41,11 @@ developmentEnvironmentUserName = Developer
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.


### PR DESCRIPTION
Not sure why these were off. Looks like they were just copied over set to false and were never enabled. Pattern variables will help clean up a lot of code.