### PR TITLE
Buff the Incenses in the Incense Crucible

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/api/sacrifice/PlayerSacrificeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/sacrifice/PlayerSacrificeHandler.java
@@ -13,7 +13,7 @@ import WayofTime.alchemicalWizardry.api.tile.IBloodAltar;
 public class PlayerSacrificeHandler {
 
     public static float scalingOfSacrifice = 0.001f;
-    public static int soulFrayDuration = 400;
+    public static int soulFrayDuration = 240;
     public static Potion soulFrayId;
 
     public static float getPlayerIncense(EntityPlayer player) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/ItemIncense.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/ItemIncense.java
@@ -142,6 +142,9 @@ public class ItemIncense extends Item implements IIncense {
         ItemStack quartzStack = new ItemStack(Items.quartz, 1, WILDCARD);
         ItemStack blazePowderStack = new ItemStack(Items.blaze_powder);
         ItemStack netherwartStack = new ItemStack(Items.nether_wart);
+
+        ItemStack blankSlateStack = new ItemStack(ModItems.blankSlate);
+        ItemStack reinforcedSlateStack = new ItemStack(ModItems.reinforcedSlate);
         ItemStack fracturedBoneStack = new ItemStack(ModItems.baseAlchemyItems, 1, 5);
 
         ItemStack woodashStack = new ItemStack(ModItems.itemIncense, 1, 0);
@@ -156,7 +159,7 @@ public class ItemIncense extends Item implements IIncense {
                         new ItemStack(Items.redstone),
                         leavesStack,
                         leavesStack,
-                        new ItemStack(ModItems.apprenticeBloodOrb)));
+                        new ItemStack(ModItems.weakBloodOrb)));
         GameRegistry.addRecipe(
                 new ShapelessBloodOrbRecipe(
                         new ItemStack(ModItems.itemIncense, 1, 2),
@@ -168,7 +171,7 @@ public class ItemIncense extends Item implements IIncense {
                         glowstoneStack,
                         stringStack,
                         stringStack,
-                        new ItemStack(ModItems.magicianBloodOrb)));
+                        new ItemStack(ModItems.apprenticeBloodOrb)));
         GameRegistry.addRecipe(
                 new ShapelessBloodOrbRecipe(
                         new ItemStack(ModItems.itemIncense, 1, 3),
@@ -178,7 +181,8 @@ public class ItemIncense extends Item implements IIncense {
                         soulSandStack,
                         gunpowderStack,
                         fermentedEyeStack,
-                        new ItemStack(ModItems.masterBloodOrb)));
+                        blankSlateStack,
+                        new ItemStack(ModItems.apprenticeBloodOrb)));
         GameRegistry.addRecipe(
                 new ShapelessBloodOrbRecipe(
                         new ItemStack(ModItems.itemIncense, 1, 4),
@@ -189,8 +193,8 @@ public class ItemIncense extends Item implements IIncense {
                         netherwartStack,
                         blazePowderStack,
                         fracturedBoneStack,
-                        goldNuggetStack,
-                        new ItemStack(ModItems.archmageBloodOrb)));
+                        reinforcedSlateStack,
+                        new ItemStack(ModItems.masterBloodOrb)));
     }
 
     public enum EnumIncense {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/ItemIncense.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/ItemIncense.java
@@ -199,11 +199,11 @@ public class ItemIncense extends Item implements IIncense {
 
     public enum EnumIncense {
 
-        WOODASH(0, 200, 1.0f, 1000, 0.937f, 0.898f, 0.820f),
-        RED(200, 600, 1.5f, 1000, 1.0f, 0, 0),
-        BLUE(600, 1200, 3.0f, 1000, 0, 0, 1.0f),
-        GREEN(1200, 2000, 4.0f, 1000, 0, 1.0f, 0),
-        PURPLE(2000, 3000, 5.0f, 1000, 1.0f, 0, 1.0f);
+        WOODASH(0, 400, 1.0f, 2000, 0.937f, 0.898f, 0.820f),
+        RED(400, 800, 1.5f, 2000, 1.0f, 0, 0),
+        BLUE(800, 1500, 3.0f, 2000, 0, 0, 1.0f),
+        GREEN(1500, 2400, 4.0f, 2000, 0, 1.0f, 0),
+        PURPLE(2400, 3500, 5.0f, 2000, 1.0f, 0, 1.0f);
 
         public final int minValue;
         public final int maxValue;


### PR DESCRIPTION
This PR aims to buff the incenses used in the crucible to make them available earlier and make them more powerful.
Also includes a minor tweak to the great-self sacrifice mechanic.
Feel free to tweak numbers.

First of all, incenses:
Wood Ash (Yellow): LP multiplier increased from 1.3 to 1.4.
Byrrus (Red): 1.6 -> 1.8, recipe shifted from apprentice orb to weak orb.
Livens (Blue): 2.2 -> 2.5, recipe shifted from magician orb to apprentice orb.
Viridis (Green): 3 -> 3.4, recipe shifted from master orb to apprentice orb, uses blank slates in the recipe to give more of a cost for the benefit it gives.
Purpura (Purple): 4 -> 4.5, recipe shifted from archmage to master orb, uses reinforced slates in the recipe for the same reason above.

All of the incenses have also been doubled in the duration it takes to completely use one in the crucible. (50s -> 100s)

I've also lowered the duration of the Soul Fray debuff when you use the great-self sacrifice. (20s -> 12s)
My reasoning for that is that the incenses take a while to charge up anyway. 