### PR TITLE
Allow the Orb of Armok to work from within a Blood Altar.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,11 +24,11 @@
 
 dependencies {
     api("com.github.GTNewHorizons:waila:1.8.6:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.45-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.49-GTNH:dev")
 
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.310:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.314:dev") {transitive = false }
 
-    compileOnly("com.github.GTNewHorizons:Botania:1.12.8-GTNH:api") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.12.10-GTNH:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.10:api") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev") {transitive = false }
     

--- a/src/main/java/WayofTime/alchemicalWizardry/api/items/interfaces/IBloodOrb.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/items/interfaces/IBloodOrb.java
@@ -5,4 +5,8 @@ public interface IBloodOrb {
     int getMaxEssence();
 
     int getOrbLevel();
+
+    default boolean isFilledForFree() {
+        return false;
+    }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
@@ -629,6 +629,28 @@ public class TEAltar extends TEInventory implements IFluidTank, IFluidHandler, I
                 return;
             }
 
+            if ("item.orb_armok".equals(returnedItem.getUnlocalizedName())) {
+                // Creative orb. Fill owner's network to the maximum, affected by altar runes.
+                SoulNetworkHandler
+                        .setCurrentEssence(ownerName, (int) (item.getMaxEssence() * this.orbCapacityMultiplier));
+
+                if (totalWorldTime % 4 == 0) {
+                    SpellHelper.sendIndexedParticleToAllAround(
+                            worldObj,
+                            xCoord,
+                            yCoord,
+                            zCoord,
+                            20,
+                            worldObj.provider.dimensionId,
+                            3,
+                            xCoord,
+                            yCoord,
+                            zCoord);
+                }
+
+                return;
+            }
+
             if (fluid != null && fluid.amount >= 1) {
                 int liquidDrained = Math.min(
                         (int) (upgradeLevel >= 2 ? consumptionRate * (1 + consumptionMultiplier) : consumptionRate),

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
@@ -629,11 +629,12 @@ public class TEAltar extends TEInventory implements IFluidTank, IFluidHandler, I
                 return;
             }
 
-            if ("item.orb_armok".equals(returnedItem.getUnlocalizedName())) {
-                // Creative orb. Fill owner's network to the maximum, affected by altar runes.
-                SoulNetworkHandler.setCurrentEssence(
+            if (item.isFilledForFree()) {
+                // Fill owner's network to the maximum, affected by altar runes.
+                SoulNetworkHandler.addCurrentEssenceToMaximum(
                         ownerName,
-                        (int) Math.min(Integer.MAX_VALUE, (long) (item.getMaxEssence() * this.orbCapacityMultiplier)));
+                        Integer.MAX_VALUE,
+                        (int) Math.min(Integer.MAX_VALUE, (long) item.getMaxEssence() * this.orbCapacityMultiplier));
 
                 if (totalWorldTime % 4 == 0) {
                     SpellHelper.sendIndexedParticleToAllAround(

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
@@ -631,8 +631,9 @@ public class TEAltar extends TEInventory implements IFluidTank, IFluidHandler, I
 
             if ("item.orb_armok".equals(returnedItem.getUnlocalizedName())) {
                 // Creative orb. Fill owner's network to the maximum, affected by altar runes.
-                SoulNetworkHandler
-                        .setCurrentEssence(ownerName, (int) (item.getMaxEssence() * this.orbCapacityMultiplier));
+                SoulNetworkHandler.setCurrentEssence(
+                        ownerName,
+                        (int) Math.min(Integer.MAX_VALUE, (long) (item.getMaxEssence() * this.orbCapacityMultiplier)));
 
                 if (totalWorldTime % 4 == 0) {
                     SpellHelper.sendIndexedParticleToAllAround(


### PR DESCRIPTION
Currently, the Orb of Armok acts as a "creative" source of LP, permanently refilling the player's network to 1,000,000,000 LP as long as it is in the player's inventory. However, this restriction can be inconvenient if the player has any rituals or other LP using contraptions permanently active. In this case, in order to keep them running, the orb must remain in the player's inventory, otherwise LP will exhaust as normal.

This PR adds a new functionality: the player can place their Orb of Armok into a Blood Altar, and the altar will keep the player's network permanently full, without having to keep the orb in inventory. This method also takes into account the Runes of the Orb placed around the altar, and refills the network up to the boosted maximum.

Note that for this to work the altar **must contain some quantity of blood** (although no blood is consumed by this process). The altar has a short-circuit that skips most of its functionality if it is empty; and I do not want to override this for performance reasons.

I have tested this change both standalone, and in the full 2.7.4 pack.