### PR TITLE
Show Required Reagents for Fillers Replaced by Reagents

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -396,8 +396,16 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
     private String reagentFillerBlockNames(MeteorReagent mr) {
         ArrayList<String> blockNames = new ArrayList<>();
         for (MeteorComponent mc : mr.filler) {
-            blockNames.add(mc.getBlock().getDisplayName());
+            blockNames.add(mc.getBlock().getDisplayName() + requiredReagentsForFiller(mc));
         }
         return Joiner.on(", ").join(blockNames);
+    }
+
+    private String requiredReagentsForFiller(MeteorComponent mc) {
+        List<Reagent> reagents = mc.getRequiredReagents();
+        if (reagents.isEmpty()) return "";
+        return " (" + reagents.stream()
+                .map(r -> r.name)
+                .collect(Collectors.joining(", ")) + ")";
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -404,8 +404,6 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
     private String requiredReagentsForFiller(MeteorComponent mc) {
         List<Reagent> reagents = mc.getRequiredReagents();
         if (reagents.isEmpty()) return "";
-        return " (" + reagents.stream()
-                .map(r -> r.name)
-                .collect(Collectors.joining(", ")) + ")";
+        return " (" + reagents.stream().map(r -> r.name).collect(Collectors.joining(", ")) + ")";
     }
 }


### PR DESCRIPTION
Show the required reagents for filler blocks replaced by reagents:
![image](https://github.com/user-attachments/assets/004c82e8-b238-4b92-b4d1-c453e57c906a)

With this custom config for virtus:
```json
{
  "invertExplosionBlockDamage": true,
  "filler": [
    "minecraft:dirt:0:60:terrae,orbisTerrae",
    "minecraft:grass:0:40:sanctus",
    "minecraft:stone:0:20"
  ]
}
```