### PR TITLE
Show capacity of Blood Orbs in the tooltip.

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/EnergyBattery.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/EnergyBattery.java
@@ -43,6 +43,7 @@ public class EnergyBattery extends Item implements ArmourUpgrade, IBindable, IBl
     @Override
     public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
         par3List.add(StatCollector.translateToLocal("tooltip.energybattery.desc"));
+        par3List.add(StatCollector.translateToLocalFormatted("tooltip.energybattery.capacity", this.getMaxEssence()));
         addBindingInformation(par1ItemStack, par3List);
     }
 

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -461,6 +461,7 @@ tooltip.divinationsigil.desc1=Peer into the soul to
 tooltip.divinationsigil.desc2=get the current essence
 tooltip.energybazooka.desc=Boom.
 tooltip.energybattery.desc=Stores raw Life Essence
+tooltip.energybattery.capacity=Capacity: %,d LP
 tooltip.energyblast.desc1=Used to fire devastating
 tooltip.energyblast.desc2=projectiles.
 tooltip.enhancedtelepfocus.desc=A focus further enhanced in an altar

--- a/src/main/resources/assets/alchemicalwizardry/lang/zh_CN.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/zh_CN.lang
@@ -434,6 +434,7 @@ tooltip.divinationsigil.desc1=凝视着灵魂
 tooltip.divinationsigil.desc2=获取当前生命本质的情况
 tooltip.energybazooka.desc=Boom.
 tooltip.energybattery.desc=存储原始的生命本质
+tooltip.energybattery.capacity=容量: %,d LP
 tooltip.energyblast.desc1=用于发射
 tooltip.energyblast.desc2=毁灭性的炮弹.
 tooltip.enhancedtelepfocus.desc=一个核心在祭坛中进一步加强


### PR DESCRIPTION
I always found it weird that this information is not available *anywhere*. Now you know what you're getting into if you want to upgrade your orb for better rituals.

![](https://i.imgur.com/aijp5vS.png)

This is just the *capacity*, if you want to see your current amount you still need to use a Sigil of Divination.

Does not dynamically update if you put the orb in an altar with Runes of the Orb and then somehow peek at its tooltip. Why would you do that?