### PR TITLE
Altar Blocks Config

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -496,12 +496,18 @@ public class AlchemicalWizardry {
     public static boolean disableBoundToolsRightClick;
     public static boolean allowPotionRepair;
 
-    public static BlockStack[] secondTierRunes = new BlockStack[10];
-    public static BlockStack[] thirdTierRunes = new BlockStack[10];
-    public static BlockStack[] fourthTierRunes = new BlockStack[10];
-    public static BlockStack[] fifthTierRunes = new BlockStack[10];
-    public static BlockStack[] sixthTierRunes = new BlockStack[10];
-    public static BlockStack[] specialAltarBlock = new BlockStack[7];
+    public static List<BlockStack> secondTierRunes;
+    public static List<BlockStack> thirdTierRunes;
+    public static List<BlockStack> fourthTierRunes;
+    public static List<BlockStack> fifthTierRunes;
+    public static List<BlockStack> sixthTierRunes;
+    public static List<BlockStack> fifthTierBeacons;
+    public static List<BlockStack> thirdTierCaps;
+    public static List<BlockStack> thirdTierPillars;
+    public static List<BlockStack> fourthTierCaps;
+    public static List<BlockStack> fourthTierPillars;
+    public static List<BlockStack> sixthTierCaps;
+    public static List<BlockStack> sixthTierPillars;
 
     public static int lpPerSelfSacrifice = 200;
     public static int lpPerSelfSacrificeSoulFray = 20;

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -16,7 +16,6 @@ import net.minecraft.entity.monster.EntityEnderman;
 import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.passive.EntityVillager;
-import net.minecraft.init.Blocks;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.oredict.OreDictionary;
@@ -624,66 +623,63 @@ public class BloodMagicConfiguration {
     }
 
     public static void finishLoading() {
-        AlchemicalWizardry.secondTierRunes = BloodMagicConfiguration.getAltarRunesForTier(
-                "secondTier",
-                new BlockStack[] { new BlockStack(ModBlocks.bloodRune, 0), new BlockStack(ModBlocks.speedRune, 0),
-                        new BlockStack(ModBlocks.efficiencyRune, 0), new BlockStack(ModBlocks.runeOfSacrifice, 0),
-                        new BlockStack(ModBlocks.runeOfSelfSacrifice, 0), new BlockStack(ModBlocks.bloodRune, 1),
-                        new BlockStack(ModBlocks.bloodRune, 2), new BlockStack(ModBlocks.bloodRune, 3),
-                        new BlockStack(ModBlocks.bloodRune, 4), new BlockStack(ModBlocks.bloodRune, 5),
-                        new BlockStack(ModBlocks.bloodRune, 6) });
-        AlchemicalWizardry.thirdTierRunes = BloodMagicConfiguration.getAltarRunesForTier(
-                "thirdTier",
-                new BlockStack[] { new BlockStack(ModBlocks.bloodRune, 0), new BlockStack(ModBlocks.speedRune, 0),
-                        new BlockStack(ModBlocks.efficiencyRune, 0), new BlockStack(ModBlocks.runeOfSacrifice, 0),
-                        new BlockStack(ModBlocks.runeOfSelfSacrifice, 0), new BlockStack(ModBlocks.bloodRune, 1),
-                        new BlockStack(ModBlocks.bloodRune, 2), new BlockStack(ModBlocks.bloodRune, 3),
-                        new BlockStack(ModBlocks.bloodRune, 4), new BlockStack(ModBlocks.bloodRune, 5),
-                        new BlockStack(ModBlocks.bloodRune, 6) });
-        AlchemicalWizardry.fourthTierRunes = BloodMagicConfiguration.getAltarRunesForTier(
-                "fourthTier",
-                new BlockStack[] { new BlockStack(ModBlocks.bloodRune, 0), new BlockStack(ModBlocks.speedRune, 0),
-                        new BlockStack(ModBlocks.efficiencyRune, 0), new BlockStack(ModBlocks.runeOfSacrifice, 0),
-                        new BlockStack(ModBlocks.runeOfSelfSacrifice, 0), new BlockStack(ModBlocks.bloodRune, 1),
-                        new BlockStack(ModBlocks.bloodRune, 2), new BlockStack(ModBlocks.bloodRune, 3),
-                        new BlockStack(ModBlocks.bloodRune, 4), new BlockStack(ModBlocks.bloodRune, 5),
-                        new BlockStack(ModBlocks.bloodRune, 6) });
-        AlchemicalWizardry.fifthTierRunes = BloodMagicConfiguration.getAltarRunesForTier(
-                "fifthTier",
-                new BlockStack[] { new BlockStack(ModBlocks.bloodRune, 0), new BlockStack(ModBlocks.speedRune, 0),
-                        new BlockStack(ModBlocks.efficiencyRune, 0), new BlockStack(ModBlocks.runeOfSacrifice, 0),
-                        new BlockStack(ModBlocks.runeOfSelfSacrifice, 0), new BlockStack(ModBlocks.bloodRune, 1),
-                        new BlockStack(ModBlocks.bloodRune, 2), new BlockStack(ModBlocks.bloodRune, 3),
-                        new BlockStack(ModBlocks.bloodRune, 4), new BlockStack(ModBlocks.bloodRune, 5),
-                        new BlockStack(ModBlocks.bloodRune, 6) });
-        AlchemicalWizardry.sixthTierRunes = BloodMagicConfiguration.getAltarRunesForTier(
-                "sixthTier",
-                new BlockStack[] { new BlockStack(ModBlocks.bloodRune, 0), new BlockStack(ModBlocks.speedRune, 0),
-                        new BlockStack(ModBlocks.efficiencyRune, 0), new BlockStack(ModBlocks.runeOfSacrifice, 0),
-                        new BlockStack(ModBlocks.runeOfSelfSacrifice, 0), new BlockStack(ModBlocks.bloodRune, 1),
-                        new BlockStack(ModBlocks.bloodRune, 2), new BlockStack(ModBlocks.bloodRune, 3),
-                        new BlockStack(ModBlocks.bloodRune, 4), new BlockStack(ModBlocks.bloodRune, 5),
-                        new BlockStack(ModBlocks.bloodRune, 6) });
-        AlchemicalWizardry.specialAltarBlock = getAltarRunesForTier(
-                "specialBlocks",
-                new BlockStack[] { new BlockStack(Blocks.air, 0), new BlockStack(Blocks.glowstone, 0),
-                        new BlockStack(Blocks.air, 0), new BlockStack(ModBlocks.largeBloodStoneBrick, 0),
-                        new BlockStack(Blocks.beacon, 0), new BlockStack(Blocks.air, 0),
-                        new BlockStack(ModBlocks.blockCrystal, 0) },
-                "Set the special blocks for the altar with the format mod:block(:meta) in the following order:\n"
-                        + "Tier 3 pillar\n"
-                        + "Tier 3 cap\n"
-                        + "Tier 4 pillar\n"
-                        + "Tier 4 cap\n"
-                        + "Tier 5 beacon\n"
-                        + "Tier 6 pillar\n"
-                        + "Tier 6 cap\n"
-                        + "Set any of these to minecraft:air to allow for that component to be any block EXCEPT air (e.g., let any block be used for a pillar).");
+        String[] defaultRunes = { "AWWayofTime:AlchemicalWizardrybloodRune", "AWWayofTime:speedRune",
+                "AWWayofTime:efficiencyRune", "AWWayofTime:runeOfSacrifice", "AWWayofTime:runeOfSelfSacrifice",
+                "AWWayofTime:AlchemicalWizardrybloodRune:1", "AWWayofTime:AlchemicalWizardrybloodRune:2",
+                "AWWayofTime:AlchemicalWizardrybloodRune:3", "AWWayofTime:AlchemicalWizardrybloodRune:4",
+                "AWWayofTime:AlchemicalWizardrybloodRune:5", "AWWayofTime:AlchemicalWizardrybloodRune:6" };
+
+        AlchemicalWizardry.secondTierRunes = readRuneOverrides("secondTier", defaultRunes);
+        AlchemicalWizardry.thirdTierRunes = readRuneOverrides("thirdTier", defaultRunes);
+        AlchemicalWizardry.fourthTierRunes = readRuneOverrides("fourthTier", defaultRunes);
+        AlchemicalWizardry.fifthTierRunes = readRuneOverrides("fifthTier", defaultRunes);
+        AlchemicalWizardry.sixthTierRunes = readRuneOverrides("sixthTier", defaultRunes);
+
+        AlchemicalWizardry.fifthTierBeacons = readBlockConfig(
+                "altar blocks",
+                "fifthTierBeacons",
+                new String[] { "minecraft:beacon", "etfuturum:beacon", "chisel:beacon:*" },
+                "Valid blocks for the Blood Altar's tier 5 beacons:\n"
+                        + "Use the following format for all of these entries: mod:block(:meta). Meta * or 32767 allows for any meta.\n"
+                        + "An empty entry allows for any non-air block to be used for that part of the structure.\n"
+                        + "Invalid or missing blocks are skipped. If all entries are invalid, any block can be used as a fallback.");
+        AlchemicalWizardry.thirdTierCaps = readBlockConfig(
+                "altar blocks",
+                "thirdTierCaps",
+                new String[] { "minecraft:glowstone", "BloodArsenal:blood_infused_glowstone", "Botania:seaLamp",
+                        "chisel:glowstone:*", "etfuturum:sea_lantern", "etfuturum:shroomlight",
+                        "ExtraUtilities:color_lightgem:*" },
+                "Valid blocks for the Blood Altar's tier 3 caps:");
+        AlchemicalWizardry.thirdTierPillars = readBlockConfig(
+                "altar blocks",
+                "thirdTierPillars",
+                new String[] {},
+                "Valid blocks for the Blood Altar's tier 3 pillars:");
+        AlchemicalWizardry.fourthTierCaps = readBlockConfig(
+                "altar blocks",
+                "fourthTierCaps",
+                new String[] { "AWWayofTime:largeBloodStoneBrick" },
+                "Valid blocks for the Blood Altar's tier 4 caps:");
+        AlchemicalWizardry.fourthTierPillars = readBlockConfig(
+                "altar blocks",
+                "fourthTierPillars",
+                new String[] {},
+                "Valid blocks for the Blood Altar's tier 4 pillars.");
+        AlchemicalWizardry.sixthTierCaps = readBlockConfig(
+                "altar blocks",
+                "sixthTierCaps",
+                new String[] { "AWWayofTime:blockCrystal" },
+                "Valid blocks for the Blood Altar's tier 6 caps:");
+        AlchemicalWizardry.sixthTierPillars = readBlockConfig(
+                "altar blocks",
+                "sixthTierPillars",
+                new String[] {},
+                "Valid blocks for the Blood Altar's tier 6 pillars:");
         config.save();
     }
 
     public static void loadCustomLPValues() {
-        AlchemicalWizardry.lpPerSactificeCustom = new HashMap<Class<?>, Integer>();
+        AlchemicalWizardry.lpPerSactificeCustom = new HashMap<>();
         for (Object object : EntityList.stringToClassMapping.entrySet()) {
             Entry entry = (Entry) object;
             String entityName = (String) entry.getKey();
@@ -798,7 +794,6 @@ public class BloodMagicConfiguration {
                 // Check if it's an int, if so, parse it. If not, set meta to 0 to avoid crashing.
                 if (isInteger(blockData[2])) meta = Integer.parseInt(blockData[2]);
                 else if (blockData[2].equals("*")) meta = OreDictionary.WILDCARD_VALUE;
-                else meta = 0;
             }
 
             AlchemicalWizardryEventHooks.teleposerBlacklist.add(new BlockStack(block, meta));
@@ -808,53 +803,43 @@ public class BloodMagicConfiguration {
     private static boolean isInteger(String s) {
         try {
             Integer.parseInt(s);
-        } catch (NumberFormatException e) {
-            return false;
-        } catch (NullPointerException e) {
+        } catch (NumberFormatException | NullPointerException e) {
             return false;
         }
-        // only got here if we didn't return false
         return true;
     }
 
-    private static BlockStack[] getAltarRunesForTier(String tierName, BlockStack[] defaultValues) {
-        return getAltarRunesForTier(tierName, defaultValues, "");
+    private static List<BlockStack> readRuneOverrides(String key, String[] defaultValues) {
+        return readBlockConfig("rune overrides", key, defaultValues, "");
     }
 
-    private static BlockStack[] getAltarRunesForTier(String tierName, BlockStack[] defaultValues, String comment) {
-        String[] defaultNames = new String[defaultValues.length];
-        for (int i = 0; i < defaultValues.length; i++) {
-            defaultNames[i] = Block.blockRegistry.getNameForObject(defaultValues[i].getBlock()) + ":"
-                    + defaultValues[i].getMeta();
-        }
-        Property property = config.get("rune overrides", tierName, defaultNames, comment);
-        String[] names = property.getStringList();
-        if (names.length != defaultNames.length) {
-            property.set(defaultNames);
-            return defaultValues;
-        }
-        BlockStack[] blockStacks = new BlockStack[names.length];
-        for (int i = 0; i < names.length; i++) {
-            String[] parts = names[i].split(":");
-            if (parts.length < 2 || parts.length > 3) {
-                property.set(defaultNames);
-                return defaultValues;
+    private static List<BlockStack> readBlockConfig(String category, String key, String[] defaultValues,
+            String comment) {
+        Property property = config.get(category, key, defaultValues, comment);
+        List<BlockStack> validStacks = new ArrayList<>();
+
+        for (String name : property.getStringList()) {
+            String[] blockData = name.split(":");
+            if (blockData.length < 2 || blockData.length > 3) {
+                continue;
             }
-            Block block = GameRegistry.findBlock(parts[0], parts[1]);
-            int metadata = 0;
-            if (parts.length == 3) {
-                try {
-                    metadata = Integer.parseInt(parts[2]);
-                } catch (NumberFormatException exception) {
-                    metadata = 0;
-                }
-            }
+
+            Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
             if (block == null) {
-                property.set(defaultNames);
-                return defaultValues;
+                AlchemicalWizardry.logger.info("Block not found for {} {}: {}", category, key, name);
+                continue;
             }
-            blockStacks[i] = new BlockStack(block, metadata);
+
+            int meta = 0;
+            if (blockData.length == 3) {
+                if (isInteger(blockData[2])) meta = Integer.parseInt(blockData[2]);
+                else if (blockData[2].equals("*")) meta = OreDictionary.WILDCARD_VALUE;
+            }
+
+            validStacks.add(new BlockStack(block, meta));
         }
-        return blockStacks;
+
+        return validStacks;
     }
+
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/api/BlockStack.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/BlockStack.java
@@ -9,8 +9,8 @@ import cpw.mods.fml.common.registry.GameData;
  */
 public class BlockStack {
 
-    private Block block;
-    private int meta;
+    private final Block block;
+    private final int meta;
 
     public BlockStack(Block block, int meta) {
         this.block = block;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/AltarComponent.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/AltarComponent.java
@@ -49,14 +49,14 @@ public class AltarComponent {
     }
 
     public Block getBlock() {
-        if (validBlocks.isEmpty()) {
+        if (anyBlockMatches()) {
             return Blocks.air;
         }
         return validBlocks.get(0).getBlock();
     }
 
     public int getMetadata() {
-        if (validBlocks.isEmpty()) {
+        if (anyBlockMatches()) {
             return OreDictionary.WILDCARD_VALUE;
         }
         return validBlocks.get(0).getMeta();
@@ -75,7 +75,7 @@ public class AltarComponent {
     }
 
     public boolean matches(Block block, int meta) {
-        if (validBlocks.isEmpty()) return true;
+        if (anyBlockMatches()) return true;
 
         for (BlockStack pair : validBlocks) {
             if (pair.getBlock() == block
@@ -84,5 +84,9 @@ public class AltarComponent {
             }
         }
         return false;
+    }
+
+    public boolean anyBlockMatches() {
+        return validBlocks.isEmpty();
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/AltarComponent.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/AltarComponent.java
@@ -1,23 +1,37 @@
 package WayofTime.alchemicalWizardry.common.bloodAltarUpgrade;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraftforge.oredict.OreDictionary;
+
+import WayofTime.alchemicalWizardry.api.BlockStack;
 
 public class AltarComponent {
 
-    private int x;
-    private int y;
-    private int z;
-    private Block block;
-    private int metadata;
-    private boolean isBloodRune;
-    private boolean isUpgradeSlot;
+    private final int x, y, z;
+    private final List<BlockStack> validBlocks;
+
+    private final boolean isBloodRune, isUpgradeSlot;
 
     public AltarComponent(int x, int y, int z, Block block, int metadata, boolean isBloodRune, boolean isUpgradeSlot) {
         this.x = x;
         this.y = y;
         this.z = z;
-        this.block = block;
-        this.metadata = metadata;
+        this.validBlocks = new ArrayList<>();
+        this.validBlocks.add(new BlockStack(block, metadata));
+        this.isBloodRune = isBloodRune;
+        this.isUpgradeSlot = isUpgradeSlot;
+    }
+
+    public AltarComponent(int x, int y, int z, List<BlockStack> validBlocks, boolean isBloodRune,
+            boolean isUpgradeSlot) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.validBlocks = validBlocks;
         this.isBloodRune = isBloodRune;
         this.isUpgradeSlot = isUpgradeSlot;
     }
@@ -35,11 +49,17 @@ public class AltarComponent {
     }
 
     public Block getBlock() {
-        return block;
+        if (validBlocks.isEmpty()) {
+            return Blocks.air;
+        }
+        return validBlocks.get(0).getBlock();
     }
 
     public int getMetadata() {
-        return metadata;
+        if (validBlocks.isEmpty()) {
+            return OreDictionary.WILDCARD_VALUE;
+        }
+        return validBlocks.get(0).getMeta();
     }
 
     public boolean isBloodRune() {
@@ -48,5 +68,21 @@ public class AltarComponent {
 
     public boolean isUpgradeSlot() {
         return isUpgradeSlot;
+    }
+
+    public List<BlockStack> getValidBlocks() {
+        return validBlocks;
+    }
+
+    public boolean matches(Block block, int meta) {
+        if (validBlocks.isEmpty()) return true;
+
+        for (BlockStack pair : validBlocks) {
+            if (pair.getBlock() == block
+                    && (pair.getMeta() == meta || pair.getMeta() == OreDictionary.WILDCARD_VALUE)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -1,11 +1,9 @@
 package WayofTime.alchemicalWizardry.common.bloodAltarUpgrade;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
@@ -47,21 +45,15 @@ public class UpgradedAltars {
         return true;
     }
 
-    private static BlockStack[] getRuneOverrides(int altarTier) {
-        switch (altarTier) {
-            case 2:
-                return AlchemicalWizardry.secondTierRunes;
-            case 3:
-                return AlchemicalWizardry.thirdTierRunes;
-            case 4:
-                return AlchemicalWizardry.fourthTierRunes;
-            case 5:
-                return AlchemicalWizardry.fifthTierRunes;
-            case 6:
-                return AlchemicalWizardry.sixthTierRunes;
-            default:
-                return null;
-        }
+    private static List<BlockStack> getRuneOverrides(int altarTier) {
+        return switch (altarTier) {
+            case 2 -> AlchemicalWizardry.secondTierRunes;
+            case 3 -> AlchemicalWizardry.thirdTierRunes;
+            case 4 -> AlchemicalWizardry.fourthTierRunes;
+            case 5 -> AlchemicalWizardry.fifthTierRunes;
+            case 6 -> AlchemicalWizardry.sixthTierRunes;
+            default -> null;
+        };
     }
 
     private static boolean checkAltarComponent(AltarComponent altarComponent, IBlockAccess world, int x, int y, int z,
@@ -69,28 +61,29 @@ public class UpgradedAltars {
         int compX = x + altarComponent.getX();
         int compY = y + altarComponent.getY();
         int compZ = z + altarComponent.getZ();
-        if (altarComponent.getBlock() == Blocks.air) {
+        if (altarComponent.anyBlockMatches()) {
             return !world.isAirBlock(compX, compY, compZ);
         }
+
         Block block = world.getBlock(compX, compY, compZ);
-        int metadata = world.getBlockMetadata(compX, compY, compZ);
-        if (altarComponent.isBloodRune()) {
-            boolean result = false;
-            BlockStack[] runes = getRuneOverrides(altarTier);
-            if (runes == null) {
-                return false;
-            }
-            for (BlockStack rune : runes) {
-                result |= altarComponent.isUpgradeSlot() ? block == rune.getBlock() && metadata == rune.getMeta()
-                        : block == altarComponent.getBlock() && metadata == altarComponent.getMetadata();
-            }
-            return result;
-        } else {
-            if (altarComponent.getBlock() != block || altarComponent.getMetadata() != metadata) {
-                return false;
+        int meta = world.getBlockMetadata(compX, compY, compZ);
+        if (!altarComponent.isBloodRune()) {
+            return altarComponent.matches(block, meta);
+        }
+
+        List<BlockStack> runes = getRuneOverrides(altarTier);
+        if (runes == null) {
+            return false;
+        }
+
+        for (BlockStack rune : runes) {
+            if (altarComponent.isUpgradeSlot() ? block == rune.getBlock() && meta == rune.getMeta()
+                    : altarComponent.matches(block, meta)) {
+                return true;
             }
         }
-        return true;
+
+        return false;
     }
 
     public static AltarUpgradeComponent getUpgrades(World world, int x, int y, int z, int altarTier) {
@@ -99,683 +92,132 @@ public class UpgradedAltars {
         }
         AltarUpgradeComponent upgrades = new AltarUpgradeComponent();
         List<AltarComponent> list = UpgradedAltars.getAltarUpgradeListForTier(altarTier);
-        BlockStack[] runes = getRuneOverrides(altarTier);
+        List<BlockStack> runes = getRuneOverrides(altarTier);
         if (list == null || runes == null) {
             return upgrades;
         }
         for (AltarComponent altarComponent : list) {
-            if (altarComponent.isUpgradeSlot()) {
-                Block block = world
-                        .getBlock(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
-                int metadata = world.getBlockMetadata(
-                        x + altarComponent.getX(),
-                        y + altarComponent.getY(),
-                        z + altarComponent.getZ());
-                BlockStack blockStack = new BlockStack(block, metadata);
-                switch (Arrays.asList(runes).indexOf(blockStack)) {
-                    case 1:
-                        upgrades.addSpeedUpgrade();
-                        break;
+            if (!altarComponent.isUpgradeSlot()) {
+                continue;
+            }
 
-                    case 2:
-                        upgrades.addEfficiencyUpgrade();
-                        break;
-
-                    case 3:
-                        upgrades.addSacrificeUpgrade();
-                        break;
-
-                    case 4:
-                        upgrades.addSelfSacrificeUpgrade();
-                        break;
-
-                    case 5:
-                        upgrades.addaltarCapacitiveUpgrade();
-                        break;
-
-                    case 6:
-                        upgrades.addDisplacementUpgrade();
-                        break;
-
-                    case 7:
-                        upgrades.addorbCapacitiveUpgrade();
-                        break;
-
-                    case 8:
-                        upgrades.addBetterCapacitiveUpgrade();
-                        break;
-
-                    case 9:
-                        upgrades.addAccelerationUpgrade();
-                        break;
-
-                    case 10:
-                        upgrades.addQuicknessUpgrade();
-                        break;
-                }
+            Block block = world
+                    .getBlock(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
+            int metadata = world
+                    .getBlockMetadata(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
+            BlockStack blockStack = new BlockStack(block, metadata);
+            switch (runes.indexOf(blockStack)) {
+                case 1 -> upgrades.addSpeedUpgrade();
+                case 2 -> upgrades.addEfficiencyUpgrade();
+                case 3 -> upgrades.addSacrificeUpgrade();
+                case 4 -> upgrades.addSelfSacrificeUpgrade();
+                case 5 -> upgrades.addaltarCapacitiveUpgrade();
+                case 6 -> upgrades.addDisplacementUpgrade();
+                case 7 -> upgrades.addorbCapacitiveUpgrade();
+                case 8 -> upgrades.addBetterCapacitiveUpgrade();
+                case 9 -> upgrades.addAccelerationUpgrade();
+                case 10 -> upgrades.addQuicknessUpgrade();
             }
         }
         return upgrades;
     }
 
     public static void loadAltars() {
-        secondTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        false));
-        secondTierAltar.add(
-                new AltarComponent(
-                        0,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        secondTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        false));
-        secondTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        0,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        secondTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        0,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        secondTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        false));
-        secondTierAltar.add(
-                new AltarComponent(
-                        0,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        secondTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        false));
+        secondTierAltar.add(new AltarComponent(-1, -1, -1, AlchemicalWizardry.secondTierRunes, true, false));
+        secondTierAltar.add(new AltarComponent(0, -1, -1, AlchemicalWizardry.secondTierRunes, true, true));
+        secondTierAltar.add(new AltarComponent(1, -1, -1, AlchemicalWizardry.secondTierRunes, true, false));
+        secondTierAltar.add(new AltarComponent(-1, -1, 0, AlchemicalWizardry.secondTierRunes, true, true));
+        secondTierAltar.add(new AltarComponent(1, -1, 0, AlchemicalWizardry.secondTierRunes, true, true));
+        secondTierAltar.add(new AltarComponent(-1, -1, 1, AlchemicalWizardry.secondTierRunes, true, false));
+        secondTierAltar.add(new AltarComponent(0, -1, 1, AlchemicalWizardry.secondTierRunes, true, true));
+        secondTierAltar.add(new AltarComponent(1, -1, 1, AlchemicalWizardry.secondTierRunes, true, false));
 
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        0,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        -1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        0,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        0,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -1,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        0,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        1,
-                        -1,
-                        1,
-                        AlchemicalWizardry.secondTierRunes[0].getBlock(),
-                        AlchemicalWizardry.secondTierRunes[0].getMeta(),
-                        true,
-                        true));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        -1,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        0,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        -1,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        0,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        -1,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        0,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        -1,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        0,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[0].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[0].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        1,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[1].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[1].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        1,
-                        -3,
-                        AlchemicalWizardry.specialAltarBlock[1].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[1].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        -3,
-                        1,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[1].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[1].getMeta(),
-                        false,
-                        false));
-        thirdTierAltar.add(
-                new AltarComponent(
-                        3,
-                        1,
-                        3,
-                        AlchemicalWizardry.specialAltarBlock[1].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[1].getMeta(),
-                        false,
-                        false));
+        thirdTierAltar.add(new AltarComponent(-1, -1, -1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(0, -1, -1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(1, -1, -1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(-1, -1, 0, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(1, -1, 0, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(-1, -1, 1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(0, -1, 1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(1, -1, 1, AlchemicalWizardry.secondTierRunes, true, true));
+        thirdTierAltar.add(new AltarComponent(-3, -1, -3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(-3, 0, -3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(3, -1, -3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(3, 0, -3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(-3, -1, 3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(-3, 0, 3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(3, -1, 3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(3, 0, 3, AlchemicalWizardry.thirdTierPillars, false, false));
+        thirdTierAltar.add(new AltarComponent(-3, 1, -3, AlchemicalWizardry.thirdTierCaps, false, false));
+        thirdTierAltar.add(new AltarComponent(3, 1, -3, AlchemicalWizardry.thirdTierCaps, false, false));
+        thirdTierAltar.add(new AltarComponent(-3, 1, 3, AlchemicalWizardry.thirdTierCaps, false, false));
+        thirdTierAltar.add(new AltarComponent(3, 1, 3, AlchemicalWizardry.thirdTierCaps, false, false));
 
         for (int i = -2; i <= 2; i++) {
-            thirdTierAltar.add(
-                    new AltarComponent(
-                            3,
-                            -2,
-                            i,
-                            AlchemicalWizardry.thirdTierRunes[0].getBlock(),
-                            AlchemicalWizardry.thirdTierRunes[0].getMeta(),
-                            true,
-                            true));
-            thirdTierAltar.add(
-                    new AltarComponent(
-                            -3,
-                            -2,
-                            i,
-                            AlchemicalWizardry.thirdTierRunes[0].getBlock(),
-                            AlchemicalWizardry.thirdTierRunes[0].getMeta(),
-                            true,
-                            true));
-            thirdTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -2,
-                            3,
-                            AlchemicalWizardry.thirdTierRunes[0].getBlock(),
-                            AlchemicalWizardry.thirdTierRunes[0].getMeta(),
-                            true,
-                            true));
-            thirdTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -2,
-                            -3,
-                            AlchemicalWizardry.thirdTierRunes[0].getBlock(),
-                            AlchemicalWizardry.thirdTierRunes[0].getMeta(),
-                            true,
-                            true));
+            thirdTierAltar.add(new AltarComponent(3, -2, i, AlchemicalWizardry.thirdTierRunes, true, true));
+            thirdTierAltar.add(new AltarComponent(-3, -2, i, AlchemicalWizardry.thirdTierRunes, true, true));
+            thirdTierAltar.add(new AltarComponent(i, -2, 3, AlchemicalWizardry.thirdTierRunes, true, true));
+            thirdTierAltar.add(new AltarComponent(i, -2, -3, AlchemicalWizardry.thirdTierRunes, true, true));
         }
 
         fourthTierAltar.addAll(thirdTierAltar);
 
         for (int i = -3; i <= 3; i++) {
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            5,
-                            -3,
-                            i,
-                            AlchemicalWizardry.fourthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fourthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            -5,
-                            -3,
-                            i,
-                            AlchemicalWizardry.fourthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fourthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -3,
-                            5,
-                            AlchemicalWizardry.fourthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fourthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -3,
-                            -5,
-                            AlchemicalWizardry.fourthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fourthTierRunes[0].getMeta(),
-                            true,
-                            true));
+            fourthTierAltar.add(new AltarComponent(5, -3, i, AlchemicalWizardry.fourthTierRunes, true, true));
+            fourthTierAltar.add(new AltarComponent(-5, -3, i, AlchemicalWizardry.fourthTierRunes, true, true));
+            fourthTierAltar.add(new AltarComponent(i, -3, 5, AlchemicalWizardry.fourthTierRunes, true, true));
+            fourthTierAltar.add(new AltarComponent(i, -3, -5, AlchemicalWizardry.fourthTierRunes, true, true));
         }
         for (int i = -2; i <= 1; i++) {
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            5,
-                            i,
-                            5,
-                            AlchemicalWizardry.specialAltarBlock[2].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[2].getMeta(),
-                            false,
-                            false));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            5,
-                            i,
-                            -5,
-                            AlchemicalWizardry.specialAltarBlock[2].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[2].getMeta(),
-                            false,
-                            false));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            -5,
-                            i,
-                            -5,
-                            AlchemicalWizardry.specialAltarBlock[2].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[2].getMeta(),
-                            false,
-                            false));
-            fourthTierAltar.add(
-                    new AltarComponent(
-                            -5,
-                            i,
-                            5,
-                            AlchemicalWizardry.specialAltarBlock[2].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[2].getMeta(),
-                            false,
-                            false));
+            fourthTierAltar.add(new AltarComponent(5, i, 5, AlchemicalWizardry.fourthTierPillars, false, false));
+            fourthTierAltar.add(new AltarComponent(5, i, -5, AlchemicalWizardry.fourthTierPillars, false, false));
+            fourthTierAltar.add(new AltarComponent(-5, i, -5, AlchemicalWizardry.fourthTierPillars, false, false));
+            fourthTierAltar.add(new AltarComponent(-5, i, 5, AlchemicalWizardry.fourthTierPillars, false, false));
         }
-        fourthTierAltar.add(
-                new AltarComponent(
-                        5,
-                        2,
-                        5,
-                        AlchemicalWizardry.specialAltarBlock[3].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[3].getMeta(),
-                        false,
-                        false));
-        fourthTierAltar.add(
-                new AltarComponent(
-                        5,
-                        2,
-                        -5,
-                        AlchemicalWizardry.specialAltarBlock[3].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[3].getMeta(),
-                        false,
-                        false));
-        fourthTierAltar.add(
-                new AltarComponent(
-                        -5,
-                        2,
-                        -5,
-                        AlchemicalWizardry.specialAltarBlock[3].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[3].getMeta(),
-                        false,
-                        false));
-        fourthTierAltar.add(
-                new AltarComponent(
-                        -5,
-                        2,
-                        5,
-                        AlchemicalWizardry.specialAltarBlock[3].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[3].getMeta(),
-                        false,
-                        false));
+        fourthTierAltar.add(new AltarComponent(5, 2, 5, AlchemicalWizardry.fourthTierCaps, false, false));
+        fourthTierAltar.add(new AltarComponent(5, 2, -5, AlchemicalWizardry.fourthTierCaps, false, false));
+        fourthTierAltar.add(new AltarComponent(-5, 2, -5, AlchemicalWizardry.fourthTierCaps, false, false));
+        fourthTierAltar.add(new AltarComponent(-5, 2, 5, AlchemicalWizardry.fourthTierCaps, false, false));
 
         fifthTierAltar.addAll(fourthTierAltar);
-        fifthTierAltar.add(
-                new AltarComponent(
-                        -8,
-                        -3,
-                        8,
-                        AlchemicalWizardry.specialAltarBlock[4].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[4].getMeta(),
-                        false,
-                        false));
-        fifthTierAltar.add(
-                new AltarComponent(
-                        -8,
-                        -3,
-                        -8,
-                        AlchemicalWizardry.specialAltarBlock[4].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[4].getMeta(),
-                        false,
-                        false));
-        fifthTierAltar.add(
-                new AltarComponent(
-                        8,
-                        -3,
-                        -8,
-                        AlchemicalWizardry.specialAltarBlock[4].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[4].getMeta(),
-                        false,
-                        false));
-        fifthTierAltar.add(
-                new AltarComponent(
-                        8,
-                        -3,
-                        8,
-                        AlchemicalWizardry.specialAltarBlock[4].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[4].getMeta(),
-                        false,
-                        false));
+        fifthTierAltar.add(new AltarComponent(-8, -3, 8, AlchemicalWizardry.fifthTierBeacons, false, false));
+        fifthTierAltar.add(new AltarComponent(-8, -3, -8, AlchemicalWizardry.fifthTierBeacons, false, false));
+        fifthTierAltar.add(new AltarComponent(8, -3, -8, AlchemicalWizardry.fifthTierBeacons, false, false));
+        fifthTierAltar.add(new AltarComponent(8, -3, 8, AlchemicalWizardry.fifthTierBeacons, false, false));
         for (int i = -6; i <= 6; i++) {
-            fifthTierAltar.add(
-                    new AltarComponent(
-                            8,
-                            -4,
-                            i,
-                            AlchemicalWizardry.fifthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fifthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fifthTierAltar.add(
-                    new AltarComponent(
-                            -8,
-                            -4,
-                            i,
-                            AlchemicalWizardry.fifthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fifthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fifthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -4,
-                            8,
-                            AlchemicalWizardry.fifthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fifthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            fifthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -4,
-                            -8,
-                            AlchemicalWizardry.fifthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.fifthTierRunes[0].getMeta(),
-                            true,
-                            true));
+            fifthTierAltar.add(new AltarComponent(8, -4, i, AlchemicalWizardry.fifthTierRunes, true, true));
+            fifthTierAltar.add(new AltarComponent(-8, -4, i, AlchemicalWizardry.fifthTierRunes, true, true));
+            fifthTierAltar.add(new AltarComponent(i, -4, 8, AlchemicalWizardry.fifthTierRunes, true, true));
+            fifthTierAltar.add(new AltarComponent(i, -4, -8, AlchemicalWizardry.fifthTierRunes, true, true));
         }
 
         sixthTierAltar.addAll(fifthTierAltar);
         for (int i = -4; i <= 2; i++) {
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            11,
-                            i,
-                            11,
-                            AlchemicalWizardry.specialAltarBlock[5].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[5].getMeta(),
-                            false,
-                            false));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            -11,
-                            i,
-                            -11,
-                            AlchemicalWizardry.specialAltarBlock[5].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[5].getMeta(),
-                            false,
-                            false));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            11,
-                            i,
-                            -11,
-                            AlchemicalWizardry.specialAltarBlock[5].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[5].getMeta(),
-                            false,
-                            false));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            -11,
-                            i,
-                            11,
-                            AlchemicalWizardry.specialAltarBlock[5].getBlock(),
-                            AlchemicalWizardry.specialAltarBlock[5].getMeta(),
-                            false,
-                            false));
+            sixthTierAltar.add(new AltarComponent(11, i, 11, AlchemicalWizardry.sixthTierPillars, false, false));
+            sixthTierAltar.add(new AltarComponent(-11, i, -11, AlchemicalWizardry.sixthTierPillars, false, false));
+            sixthTierAltar.add(new AltarComponent(11, i, -11, AlchemicalWizardry.sixthTierPillars, false, false));
+            sixthTierAltar.add(new AltarComponent(-11, i, 11, AlchemicalWizardry.sixthTierPillars, false, false));
         }
-        sixthTierAltar.add(
-                new AltarComponent(
-                        11,
-                        3,
-                        11,
-                        AlchemicalWizardry.specialAltarBlock[6].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[6].getMeta(),
-                        false,
-                        false));
-        sixthTierAltar.add(
-                new AltarComponent(
-                        -11,
-                        3,
-                        -11,
-                        AlchemicalWizardry.specialAltarBlock[6].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[6].getMeta(),
-                        false,
-                        false));
-        sixthTierAltar.add(
-                new AltarComponent(
-                        11,
-                        3,
-                        -11,
-                        AlchemicalWizardry.specialAltarBlock[6].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[6].getMeta(),
-                        false,
-                        false));
-        sixthTierAltar.add(
-                new AltarComponent(
-                        -11,
-                        3,
-                        11,
-                        AlchemicalWizardry.specialAltarBlock[6].getBlock(),
-                        AlchemicalWizardry.specialAltarBlock[6].getMeta(),
-                        false,
-                        false));
+        sixthTierAltar.add(new AltarComponent(11, 3, 11, AlchemicalWizardry.sixthTierCaps, false, false));
+        sixthTierAltar.add(new AltarComponent(-11, 3, -11, AlchemicalWizardry.sixthTierCaps, false, false));
+        sixthTierAltar.add(new AltarComponent(11, 3, -11, AlchemicalWizardry.sixthTierCaps, false, false));
+        sixthTierAltar.add(new AltarComponent(-11, 3, 11, AlchemicalWizardry.sixthTierCaps, false, false));
         for (int i = -9; i <= 9; i++) {
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            11,
-                            -5,
-                            i,
-                            AlchemicalWizardry.sixthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.sixthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            -11,
-                            -5,
-                            i,
-                            AlchemicalWizardry.sixthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.sixthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -5,
-                            11,
-                            AlchemicalWizardry.sixthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.sixthTierRunes[0].getMeta(),
-                            true,
-                            true));
-            sixthTierAltar.add(
-                    new AltarComponent(
-                            i,
-                            -5,
-                            -11,
-                            AlchemicalWizardry.sixthTierRunes[0].getBlock(),
-                            AlchemicalWizardry.sixthTierRunes[0].getMeta(),
-                            true,
-                            true));
+            sixthTierAltar.add(new AltarComponent(11, -5, i, AlchemicalWizardry.sixthTierRunes, true, true));
+            sixthTierAltar.add(new AltarComponent(-11, -5, i, AlchemicalWizardry.sixthTierRunes, true, true));
+            sixthTierAltar.add(new AltarComponent(i, -5, 11, AlchemicalWizardry.sixthTierRunes, true, true));
+            sixthTierAltar.add(new AltarComponent(i, -5, -11, AlchemicalWizardry.sixthTierRunes, true, true));
         }
     }
 
     public static List<AltarComponent> getAltarUpgradeListForTier(int tier) {
-        switch (tier) {
-            case 2:
-                return secondTierAltar;
-
-            case 3:
-                return thirdTierAltar;
-
-            case 4:
-                return fourthTierAltar;
-
-            case 5:
-                return fifthTierAltar;
-
-            case 6:
-                return sixthTierAltar;
-        }
-
-        return null;
+        return switch (tier) {
+            case 2 -> secondTierAltar;
+            case 3 -> thirdTierAltar;
+            case 4 -> fourthTierAltar;
+            case 5 -> fifthTierAltar;
+            case 6 -> sixthTierAltar;
+            default -> null;
+        };
     }
 }


### PR DESCRIPTION
Split configs for blocks used by each part of the Blood Altar's structure to allow for multiple blocks to be configured for each.

Care was taken to make this backwards compatible with other mods that used AltarStructure (Blood Arsenal and Sanguimancy are ones I'm aware of). I just found a preexisting bug with how Blood Arsenal used the existing stuff, but I will fix that.

Add some sensible default values for modded blocks to accept as part of the structure (either modified glowstone or backported blocks accepted in future versions of BM). Configs with no blocks listed will allow for any block in that position (used for the pillars in default configs). Missing blocks in config entries are simply ignored.

New valid alternate blocks are:
T3 Cap: 
- BloodArsenal:blood_infused_glowstone
- Botania:seaLamp (Sea Lantern backport)
- chisel:glowstone:* (Chiseled Glowstone)
- etfuturum:sea_lantern (Sea Lantern backport)
- etfuturum:shroomlight (Shroomlight backport)
- ExtraUtilities:color_lightgem:* (Colored Glowstone)

T5 Beacon:
- etfuturum:beacon
- chisel:beacon:*

An example altar with a mix of the new valid blocks:
<img width="2560" height="1414" alt="image" src="https://github.com/user-attachments/assets/47d90bc7-f11b-4e5c-873e-e71694f31b64" />

I will also make a PR to add these new configs to GT:NH.