### PR TITLE
Change bound tools mining level to 7

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
@@ -49,7 +49,7 @@ public class BoundAxe extends ItemAxe implements IBindable {
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         setEnergyUsed(5);
-        this.setHarvestLevel("axe", 5);
+        this.setHarvestLevel("axe", 7);
     }
 
     public void setEnergyUsed(int i) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -50,7 +50,7 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable {
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         this.setEnergyUsed(5);
-        setHarvestLevel("pickaxe", 5);
+        setHarvestLevel("pickaxe", 7);
     }
 
     public void setEnergyUsed(int i) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
@@ -51,7 +51,7 @@ public class BoundShovel extends ItemSpade implements IBindable {
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         setEnergyUsed(5);
-        setHarvestLevel("shovel", 5);
+        setHarvestLevel("shovel", 7);
     }
 
     public void setEnergyUsed(int i) {


### PR DESCRIPTION
Pull request to change the mining level of the bound tools to 7, matching the Pickaxe of the Core used for the binding ritual.

Fixing issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20828