### PR TITLE
Lossless blood orb capacity

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/LifeEssenceNetwork.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/LifeEssenceNetwork.java
@@ -19,8 +19,7 @@ public class LifeEssenceNetwork extends net.minecraft.world.WorldSavedData {
     @Override
     public void readFromNBT(NBTTagCompound nbttagcompound) {
         currentEssence = nbttagcompound.getInteger("currentEssence");
-        maxEssence = nbttagcompound.hasKey("maxEssence") ? nbttagcompound.getInteger("maxEssence")
-                : SoulNetworkHandler.getMaximumForOrbTier(maxOrb); // seamless migration from old data
+        maxEssence = nbttagcompound.getInteger("maxEssence");
         maxOrb = nbttagcompound.getInteger("maxOrb");
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/LifeEssenceNetwork.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/LifeEssenceNetwork.java
@@ -5,23 +5,29 @@ import net.minecraft.nbt.NBTTagCompound;
 public class LifeEssenceNetwork extends net.minecraft.world.WorldSavedData {
 
     public int currentEssence;
+    public int maxEssence;
     public int maxOrb;
 
     public LifeEssenceNetwork(String par1Str) {
         super(par1Str);
         currentEssence = 0;
+        // can be lower than currentEssence (overfilled) with runes of the orb
+        maxEssence = 1;
         maxOrb = 0;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbttagcompound) {
         currentEssence = nbttagcompound.getInteger("currentEssence");
+        maxEssence = nbttagcompound.hasKey("maxEssence") ? nbttagcompound.getInteger("maxEssence")
+                : SoulNetworkHandler.getMaximumForOrbTier(maxOrb); // seamless migration from old data
         maxOrb = nbttagcompound.getInteger("maxOrb");
     }
 
     @Override
     public void writeToNBT(NBTTagCompound nbttagcompound) {
         nbttagcompound.setInteger("currentEssence", currentEssence);
+        nbttagcompound.setInteger("maxEssence", maxEssence);
         nbttagcompound.setInteger("maxOrb", maxOrb);
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -376,12 +376,11 @@ public class SoulNetworkHandler {
     }
 
     public static boolean checkAndSetItemPlayer(ItemStack item, EntityPlayer player) {
-        if (item.getItem() instanceof IBloodOrb) {
+        if (item.getItem() instanceof IBloodOrb orb) {
             String currentOwner = item.hasTagCompound() ? item.getTagCompound().getString("ownerName") : "";
             String thisPlayer = getUsername(player);
             if (currentOwner.isEmpty() || currentOwner.equals(thisPlayer)) {
-                int orbCap = ((IBloodOrb) item.getItem()).getMaxEssence();
-                setMaxEssenceToMax(thisPlayer, orbCap);
+                setMaxEssenceToMax(thisPlayer, orb.getMaxEssence());
             }
         }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -15,6 +15,7 @@ import WayofTime.alchemicalWizardry.api.event.ItemBindEvent;
 import WayofTime.alchemicalWizardry.api.event.ItemDrainInContainerEvent;
 import WayofTime.alchemicalWizardry.api.event.ItemDrainNetworkEvent;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.Event.Result;
@@ -36,6 +37,10 @@ public class SoulNetworkHandler {
         return syphonFromNetwork(event.ownerNetwork, event.drainAmount) >= damageToBeDone;
     }
 
+    /**
+     * @deprecated Use {@link #getMaxEssence(String ownerName)} to get maximum soul network capacity
+     */
+    @Deprecated
     public static int getCurrentMaxOrb(String ownerName) {
         MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
         if (mcServer == null) {
@@ -53,6 +58,28 @@ public class SoulNetworkHandler {
         return data.maxOrb;
     }
 
+    public static int getMaxEssence(String ownerName) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
+            return 0;
+        }
+
+        World world = mcServer.worldServers[0];
+        LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
+
+        if (data == null) {
+            data = new LifeEssenceNetwork(ownerName);
+            world.setItemData(ownerName, data);
+        }
+
+        return data.maxEssence;
+    }
+
+    /**
+     * @deprecated Use {@link #setMaxEssenceToMax(String ownerName, int maxEssence)} to set maximum soul network
+     *             capacity
+     */
+    @Deprecated
     public static void setMaxOrbToMax(String ownerName, int maxOrb) {
         MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
         if (mcServer == null) {
@@ -71,6 +98,28 @@ public class SoulNetworkHandler {
         data.markDirty();
     }
 
+    public static void setMaxEssenceToMax(String ownerName, int maxEssence) {
+        MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+        if (mcServer == null) {
+            return;
+        }
+
+        World world = mcServer.worldServers[0];
+        LifeEssenceNetwork data = (LifeEssenceNetwork) world.loadItemData(LifeEssenceNetwork.class, ownerName);
+
+        if (data == null) {
+            data = new LifeEssenceNetwork(ownerName);
+            world.setItemData(ownerName, data);
+        }
+
+        data.maxEssence = Math.max(maxEssence, data.maxEssence);
+        data.markDirty();
+    }
+
+    /**
+     * @deprecated Use {@link #getMaxEssence(String ownerName)} to get maximum soul network capacity
+     */
+    @Deprecated
     public static int getMaximumForOrbTier(int maxOrb) {
         switch (maxOrb) {
             case 1:
@@ -327,6 +376,15 @@ public class SoulNetworkHandler {
     }
 
     public static boolean checkAndSetItemPlayer(ItemStack item, EntityPlayer player) {
+        if (item.getItem() instanceof IBloodOrb) {
+            String currentOwner = item.hasTagCompound() ? item.getTagCompound().getString("ownerName") : "";
+            String thisPlayer = getUsername(player);
+            if (currentOwner.isEmpty() || currentOwner.equals(thisPlayer)) {
+                int orbCap = ((IBloodOrb) item.getItem()).getMaxEssence();
+                setMaxEssenceToMax(thisPlayer, orbCap);
+            }
+        }
+
         if (item.hasTagCompound() && !item.getTagCompound().getString("ownerName").equals("")) return true;
 
         ItemBindEvent event = new ItemBindEvent(player, SoulNetworkHandler.getUsername(player), item);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
@@ -482,8 +482,7 @@ public class AlchemicalWizardryEventHooks {
                     NewPacketHandler.INSTANCE.sendTo(
                             NewPacketHandler.getLPPacket(
                                     SoulNetworkHandler.getCurrentEssence(ownerName),
-                                    SoulNetworkHandler
-                                            .getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(ownerName))),
+                                    SoulNetworkHandler.getMaxEssence(ownerName)),
                             (EntityPlayerMP) entityLiving);
                 }
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/CommandSN.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/CommandSN.java
@@ -69,15 +69,15 @@ public class CommandSN extends CommandBase {
                 func_152373_a(icommandsender, this, "commands.soulnetwork.get.success", currentEssence, owner);
             } else if ("fillMax".equalsIgnoreCase(astring[1])) {
                 int currentEssence = SoulNetworkHandler.getCurrentEssence(owner);
-                int orbTier = SoulNetworkHandler.getCurrentMaxOrb(owner);
-                int maxForOrb = SoulNetworkHandler.getMaximumForOrbTier(orbTier);
-                int fillAmount = maxForOrb - currentEssence;
+                int maxForUser = SoulNetworkHandler.getMaxEssence(owner);
+                int fillAmount = maxForUser - currentEssence;
                 SoulNetworkHandler.addCurrentEssenceToMaximum(owner, fillAmount, fillAmount);
                 func_152373_a(icommandsender, this, "commands.soulnetwork.fillMax.success", owner);
             } else if ("create".equalsIgnoreCase(astring[1])) {
-                int orbTier = parseIntBounded(icommandsender, astring[2], 1, 6);
-                SoulNetworkHandler.setMaxOrbToMax(proxyPlayerName.getDisplayName(), orbTier);
-                func_152373_a(icommandsender, this, "commands.soulnetwork.create.success", owner, orbTier);
+                int desiredCapacity = parseInt(icommandsender, astring[2]);
+                SoulNetworkHandler.setMaxEssenceToMax(proxyPlayerName.getDisplayName(), desiredCapacity);
+                int actualCapacity = SoulNetworkHandler.getMaxEssence(proxyPlayerName.getDisplayName());
+                func_152373_a(icommandsender, this, "commands.soulnetwork.create.success", owner, actualCapacity);
             } else {
                 throw new CommandException("commands.soulnetwork.notACommand");
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandNetwork.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandNetwork.java
@@ -85,9 +85,8 @@ public class SubCommandNetwork extends SubCommandBase {
                         if (args.length == 3) {
                             if (isInteger(args[2])) {
                                 int amount = Integer.parseInt(args[2]);
-                                int maxOrb = SoulNetworkHandler
-                                        .getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(givenName));
-                                SoulNetworkHandler.addCurrentEssenceToMaximum(givenName, amount, maxOrb);
+                                int maxEssence = SoulNetworkHandler.getMaxEssence(givenName);
+                                SoulNetworkHandler.addCurrentEssenceToMaximum(givenName, amount, maxEssence);
                                 displaySuccessString(commandSender, "commands.network.add.success", amount, givenName);
                             } else {
                                 displayErrorString(commandSender, "commands.error.arg.invalid");
@@ -152,9 +151,8 @@ public class SubCommandNetwork extends SubCommandBase {
                         }
 
                         if (args.length > 1) {
-                            int maxOrb = SoulNetworkHandler
-                                    .getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(givenName));
-                            SoulNetworkHandler.setCurrentEssence(givenName, maxOrb);
+                            int maxEssence = SoulNetworkHandler.getMaxEssence(givenName);
+                            SoulNetworkHandler.setCurrentEssence(givenName, maxEssence);
                             displaySuccessString(commandSender, "commands.network.cap.success", givenName);
                         }
 

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -417,7 +417,7 @@ commands.soulnetwork.noPlayer=There is no player specified
 commands.soulnetwork.noCommand=There is no command specified
 commands.soulnetwork.notACommand=That is not a valid command
 commands.soulnetwork.fillMax.success=Successfully filled %s's Soul Network to their orb max!
-commands.soulnetwork.create.success=Successfully created %s's Soul Network (Orb tier: %d)
+commands.soulnetwork.create.success=Successfully created %s's Soul Network (Capacity: %d)
 
 #Tooltips
 tooltip.activationcrystal.creativeonly=Creative Only - activates any ritual

--- a/src/main/resources/assets/alchemicalwizardry/lang/zh_CN.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/zh_CN.lang
@@ -389,7 +389,7 @@ commands.soulnetwork.noPlayer=没有指定玩家
 commands.soulnetwork.noCommand=命令不够详细
 commands.soulnetwork.notACommand=这不是有效的命令
 commands.soulnetwork.fillMax.success=成功填满 %s 的气血宝珠!
-commands.soulnetwork.create.success=成功创建 %s 的灵魂网络(气血宝珠等级: %d)
+commands.soulnetwork.create.success=成功创建 %s 的灵魂网络(容量: %d)
 
 #Tooltips
 tooltip.activationcrystal.creativeonly=创造模式独有 - 激活任何仪式


### PR DESCRIPTION
Now saves linked blood orb capacity directly instead of determining it through tier. Old methods are deprecated, as I see no other uses in code for tier, except determining maximum capacity. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23209
Old saves will show 1 maxEssence (as like no orb was linked) until player r-clicks their orb again.
This PR doesn't affect gameplay, only UI part
<img width="541" height="56" alt="image" src="https://github.com/user-attachments/assets/26968321-5b45-4b2b-9f1f-96422b134aef" />
