### PR TITLE
fix NPE in entity init

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntityBoulderFist.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntityBoulderFist.java
@@ -82,7 +82,6 @@ public class EntityBoulderFist extends EntityDemon {
     protected void entityInit() {
         super.entityInit();
         this.dataWatcher.addObject(18, this.getHealth());
-        this.setCombatTask();
     }
 
     protected void playStepSound(int par1, int par2, int par3, int par4) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntitySmallEarthGolem.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntitySmallEarthGolem.java
@@ -82,7 +82,6 @@ public class EntitySmallEarthGolem extends EntityDemon implements IRangedAttackM
     protected void entityInit() {
         super.entityInit();
         this.dataWatcher.addObject(18, this.getHealth());
-        this.setCombatTask();
     }
 
     protected void playStepSound(int par1, int par2, int par3, int par4) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntityWingedFireDemon.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/entity/mob/EntityWingedFireDemon.java
@@ -84,7 +84,6 @@ public class EntityWingedFireDemon extends EntityDemon implements IRangedAttackM
     protected void entityInit() {
         super.entityInit();
         this.dataWatcher.addObject(18, this.getHealth());
-        this.setCombatTask();
     }
 
     protected void playStepSound(int par1, int par2, int par3, int par4) {


### PR DESCRIPTION
introduced by https://github.com/GTNewHorizons/BloodMagic/pull/127

```
Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.entity.ai.EntityAITasks.func_85156_a(net.minecraft.entity.ai.EntityAIBase)" because "this.field_70714_bg" is null
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityBoulderFist.setCombatTask(EntityBoulderFist.java:132)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityBoulderFist.func_70088_a(EntityBoulderFist.java:85)
	at Launch//net.minecraft.entity.Entity.<init>(Entity.java:175)
	at Launch//net.minecraft.entity.EntityLivingBase.<init>(EntityLivingBase.java:119)
	at Launch//net.minecraft.entity.EntityLiving.<init>(EntityLiving.java:68)
	at Launch//net.minecraft.entity.EntityCreature.<init>(SourceFile:23)
	at Launch//net.minecraft.entity.EntityAgeable.<init>(SourceFile:17)
	at Launch//net.minecraft.entity.passive.EntityAnimal.<init>(SourceFile:26)
	at Launch//net.minecraft.entity.passive.EntityTameable.<init>(SourceFile:23)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityDemon.<init>(EntityDemon.java:33)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityBoulderFist.<init>(EntityBoulderFist.java:36)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	... 42 more

Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.entity.ai.EntityAITasks.func_85156_a(net.minecraft.entity.ai.EntityAIBase)" because "this.field_70714_bg" is null
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityWingedFireDemon.setCombatTask(EntityWingedFireDemon.java:130)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityWingedFireDemon.func_70088_a(EntityWingedFireDemon.java:87)
	at Launch//net.minecraft.entity.Entity.<init>(Entity.java:175)
	at Launch//net.minecraft.entity.EntityLivingBase.<init>(EntityLivingBase.java:119)
	at Launch//net.minecraft.entity.EntityLiving.<init>(EntityLiving.java:68)
	at Launch//net.minecraft.entity.EntityCreature.<init>(SourceFile:23)
	at Launch//net.minecraft.entity.EntityAgeable.<init>(SourceFile:17)
	at Launch//net.minecraft.entity.passive.EntityAnimal.<init>(SourceFile:26)
	at Launch//net.minecraft.entity.passive.EntityTameable.<init>(SourceFile:23)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityDemon.<init>(EntityDemon.java:33)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityWingedFireDemon.<init>(EntityWingedFireDemon.java:38)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	... 42 more

Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.entity.ai.EntityAITasks.func_85156_a(net.minecraft.entity.ai.EntityAIBase)" because "this.field_70714_bg" is null
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntitySmallEarthGolem.setCombatTask(EntitySmallEarthGolem.java:128)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntitySmallEarthGolem.func_70088_a(EntitySmallEarthGolem.java:85)
	at Launch//net.minecraft.entity.Entity.<init>(Entity.java:175)
	at Launch//net.minecraft.entity.EntityLivingBase.<init>(EntityLivingBase.java:119)
	at Launch//net.minecraft.entity.EntityLiving.<init>(EntityLiving.java:68)
	at Launch//net.minecraft.entity.EntityCreature.<init>(SourceFile:23)
	at Launch//net.minecraft.entity.EntityAgeable.<init>(SourceFile:17)
	at Launch//net.minecraft.entity.passive.EntityAnimal.<init>(SourceFile:26)
	at Launch//net.minecraft.entity.passive.EntityTameable.<init>(SourceFile:23)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntityDemon.<init>(EntityDemon.java:33)
	at Launch//WayofTime.alchemicalWizardry.common.entity.mob.EntitySmallEarthGolem.<init>(EntitySmallEarthGolem.java:38)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	... 42 more
```